### PR TITLE
docs(HardRT): align documentation with current v0.4.0 behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,181 +1,149 @@
 # 🫀 HardRT [[ExoSpaceLabs](https://github.com/ExoSpaceLabs)]
 
-**HardRT** is the heartbeat of small embedded systems.  
-A tiny, portable, modular real-time operating system written in C.  
-Minimal footprint, predictable behavior, and zero hardware dependencies in its core.
+**HardRT** is a small, portable real-time operating-system kernel written in C.
+The core uses static allocation and has no HAL dependency.
 
 **Version:** `0.4.0`
 
----
+## Features available in v0.4.0
 
-## ✨ Features
-- **Pure C core** — no dynamic allocation, no HAL dependencies.
-- **Portable ports** — currently: null, posix, cortex-m.
-- **Scheduler** — priority, round-robin, or hybrid.
-- **Task control** — `hrt_sleep()`, `hrt_yield()`, `hrt_task_delete()`, and `hrt_now_ms()` millisecond helper.
-- **Semaphores (binary + counting)** — blocking take, `try_take`, ISR-safe `give` with FIFO wake-up; counting mode via `hrt_sem_init_counting`.
-- **Mutexes** — owner-tracked, non-recursive, FIFO waiter queue with direct handoff on unlock.
-- **Message Queues** — fixed-size, copy-based FIFO, blocking/non-blocking and ISR support.
-- **Static tasks** — stacks and TCBs supplied by the application.
-- **CMake package** — install and consume via `find_package(HardRT)`.
-- **Generated metadata** — version and port headers at build time.
-- **Optional C++17 wrapper** — header-only interface target when enabled. See [C++ Guide](docs/CPP.md).
+- **Pure C core:** no dynamic allocation and no hardware abstraction layer in the kernel.
+- **Ports:** `null`, `posix`, and `cortex_m`.
+- **Static tasks:** task stacks are supplied by the application.
+- **Scheduling:** fixed-priority scheduling with optional round-robin time slicing inside priority classes.
+- **Task control:** `hrt_sleep()`, `hrt_yield()`, `hrt_task_delete()`, `hrt_tick_now()`, and `hrt_now_ms()`.
+- **Semaphores:** binary and counting modes, FIFO waiter queues, and ISR-safe give.
+- **Mutexes:** owner-tracked, non-recursive, FIFO waiter queues, and direct handoff.
+- **Message queues:** fixed-size, copy-based FIFO queues with task and ISR operations.
+- **CMake package:** installation and consumption through `find_package(HardRT)`.
+- **Optional C++17 wrapper:** header-only wrappers enabled with `HARDRT_ENABLE_CPP`.
 
-Please refer to [PORTING.md](docs/PORTING.md) for additional port inclusion.
+The current release does not provide IPC timeouts, mutex priority inheritance, event flags, task notifications, tickless idle, or high-resolution timers.
 
-> The POSIX port is for logic verification, not timing accuracy. `ucontext` is used and supported on Linux/glibc.
+## Port behavior
 
-> “On Cortex-M, the max time from tick to running the next highest priority ready task is bounded by: ISR tail + PendSV latency + context save/restore”
+The Cortex-M port uses SysTick or an application-provided external tick and performs context switching through PendSV.
 
-> The POSIX port is regularly validated on Ubuntu 22.04, Ubuntu 24.04, and GitHub CI Linux environments. A test-suite failure has been observed on Debian 13 and is currently under investigation.
----
+The POSIX port is a logic and scheduler simulator for Linux/glibc. It uses `ucontext` and a `SIGALRM` tick. The signal handler performs tick accounting and requests rescheduling, but it does not switch task contexts directly. A POSIX task returns control to the scheduler only when it calls a HardRT scheduling point, such as sleep, yield, a blocking IPC operation, task deletion, or task return. A CPU-bound task that never reaches such a point can prevent other POSIX tasks from running.
 
-### Architecture
+The POSIX port is not a timing-accurate model of Cortex-M execution. It is regularly exercised on Ubuntu and GitHub-hosted Linux runners. A test-suite failure has been observed on Debian 13 with GCC 14 and glibc 2.41.
+
+See [the porting guide](docs/PORTING.md) for the current port contract.
+
+## Architecture
 
 ![architecture](docs/images/Architecture.png)
 
-The Architecture is mainly divided into three layers:
-- **Application Layer**: Where the tasks are defined. e.g., camera, UART downlink, HK/FDIR, etc.
-- **HardRT Core**: Where the RTOS lives, manages tasks, and calls the port to switch context when necessary.
-  - **HardRT Port**: Wraps the hardware-specific methods.
-- **Hardware Layer**: Hardware specific methods, registers, primitives, etc.
+HardRT is divided into three layers:
 
-> “Event-to-task latency in HardRT depends on task priority. When multiple tasks are woken concurrently,
-> the highest-priority task consistently achieves minimal latency, while lower-priority tasks incur bounded
-> additional delay.”
+- **Application:** task functions and application-owned storage.
+- **HardRT core:** task state, ready queues, timing, and synchronization primitives.
+- **Port:** architecture-specific tick, critical-section, idle, stack-frame, and context-switch operations.
 
-### Task State Machine
-![task_state_machine.png](docs/images/task_state_machine.png)
+### Task state machine
 
-Where each task is executed in accordance with the policy adopted by the scheduler.
+![task state machine](docs/images/task_state_machine.png)
 
-> Note: If a task exits, it is automatically deleted (EXIT) and the scheduler won't requeue it.
+A task that returns from its entry function is passed to `hrt_task_delete()`, marked unused, and is not scheduled again.
 
-see also [Concepts](#-concepts)
+## Repository layout
 
-## 📁 Repository Layout
-```
+```text
 hardrt/
-├── inc/                    # Public headers
-├── src/                    # Core + port implementations
-│   ├── core/               # Kernel internals
-│   └── port/               # Architecture-specific backends (null, posix, cortex_m)
-├── cpp/                    # Optional C++17 interface
-├── cmake/                  # additional cmake files and toolchains
+├── inc/                    # Public and port-facing headers
+├── src/
+│   ├── core/               # Kernel implementation
+│   └── port/               # null, posix, and cortex_m ports
+├── cpp/                    # Optional C++17 wrapper
+├── cmake/                  # Package files and toolchains
 ├── examples/               # Example applications
 ├── tests/                  # POSIX test harness
-├── scripts/                # scripts to build and test the project
+├── scripts/                # Build and test helpers
 ├── docs/                   # Documentation
 ├── LICENSE
 └── README.md
 ```
 
----
+## Build
 
-## ⚙️ Build
 ```bash
-mkdir -p build && cd build
-cmake -DHARDRT_PORT=posix -DHARDRT_BUILD_EXAMPLES=ON ..
-cmake --build . -j$(nproc)
-./examples/two_tasks/two_tasks
-```
-Install package:
-```bash
-cmake --install . --prefix "$PWD/install"
+cmake -S . -B build \
+  -DHARDRT_PORT=posix \
+  -DHARDRT_BUILD_EXAMPLES=ON
+cmake --build build -j
+./build/examples/two_tasks/two_tasks
 ```
 
-Consume from another CMake project:
+Install the package:
+
+```bash
+cmake --install build --prefix "$PWD/build/install"
+```
+
+Consume it from another CMake project:
+
 ```cmake
 find_package(HardRT 0.4.0 REQUIRED)
 add_executable(app main.c)
 target_link_libraries(app PRIVATE HardRT::hardrt)
 ```
-For further information and CMake flags, see the [Build](docs/BUILD.md) document.
 
----
+See [BUILD.md](docs/BUILD.md) for the current prerequisites and CMake options.
 
-## 🧠 Concepts
+## Scheduling in the current implementation
 
-### Tick vs Timeslice
-- **Tick:** base time unit generated by a timer interrupt (or POSIX signal). HardRT increments a counter each tick and wakes sleepers.
-- **Timeslice:** number of ticks a task may run before being rotated under RR. In the current implementation, rotation is triggered safely through the scheduler path rather than by direct context switching inside the tick hook.
+Priority `0` is the highest priority. Ready tasks are stored in one FIFO queue per priority, and the scheduler always selects the first task from the highest non-empty priority queue.
 
+- `HRT_SCHED_PRIORITY` uses fixed-priority selection without tick-driven time-slice rotation.
+- `HRT_SCHED_RR` enables time-slice accounting, but task selection still uses the priority queues in v0.4.0.
+- `HRT_SCHED_PRIORITY_RR` also uses fixed-priority selection and rotates time-sliced tasks within the same priority class.
+- A task with `timeslice == 0` is cooperative and is not rotated when ticks expire.
 
-### Policy: Round‑robin within one priority (Sequence at tick times)
+Consequently, `HRT_SCHED_RR` is not a priority-independent global round-robin policy in the current implementation.
 
-![policy_RR.png](docs/images/policy_RR.png)
+A timeslice is expressed in **ticks**, not milliseconds. Its wall-clock duration depends on `tick_hz`.
 
-Caption:
-- Policy: `HRT_SCHED_PRIORITY_RR` (RR applies within same priority).
-- Two READY tasks with `timeslice=1 ms`. Handoffs occur exactly at every tick...
-- Self-transitions mark per-tick continuity when no interrupt/context switch occurs.
+## Tick sources
 
-![two_tick_RR.png](docs/images/two_tick_RR.png)
+- `HRT_TICK_SYSTICK`: the selected port owns the periodic tick and calls the private core tick handler.
+- `HRT_TICK_EXTERNAL`: the application owns the timer and calls `hrt_tick_from_isr()` from that timer ISR.
 
-Caption:
-- Identical example with `timeslice=2 ms` is shown above, in essence handoffs occur every two ticks.
+Tick processing increments the tick counter, wakes expired sleepers, updates the running task's slice, and requests rescheduling only when a wake-up or slice expiry requires it. It never performs a task-context switch directly.
 
-each task is executed in order.
+See [TICK_SOURCE.md](docs/TICK_SOURCE.md) for details.
 
-### Policy: Priority preemption (Sequence at tick times)
+## Task timing
 
-![preempt.png](docs/images/preempt.png)
+`hrt_sleep(ms)` converts milliseconds to ticks using ceiling division. Positive durations shorter than one tick sleep for one tick. In v0.4.0, `hrt_sleep(0)` also sleeps for one tick; use `hrt_yield()` for an immediate voluntary scheduling point.
 
-Caption:
-- this example shows four tasks with different priorities.
-- D the lowest priority task running continuously.
-- D is interrupted at T6 by Task A lasting one tick and resumes Task D.
-- D is interrupted once again by higher priority task C at T10 lasting three ticks.
-- C as well is interrupted by Task B (an even higher task) at T11 lasting two ticks.
-- B returns to C, which finishes the remaining work (two more ticks); and returns to D.
-- Self-transitions mark per-tick continuity when no interrupt/context switch occurs.
+## Synchronization
 
+### Semaphores
 
+- `hrt_sem_init`, `hrt_sem_init_counting`
+- `hrt_sem_take`, `hrt_sem_try_take`
+- `hrt_sem_give`, `hrt_sem_give_from_isr`
 
-> RR with preemption allows the usage of both policies within the same context.
-
----
-
-### Semaphores (binary + counting)
-- `hrt_sem_init`, `hrt_sem_init_counting`, `hrt_sem_take`, `hrt_sem_try_take`, `hrt_sem_give`, `hrt_sem_give_from_isr`.
-- Use semaphores for **event signaling**, **resource counting**, and producer/consumer synchronization.
+Semaphores use FIFO waiter queues and direct handoff. They are not owner-tracked.
 
 ### Mutexes
-- `hrt_mutex_init`, `hrt_mutex_lock`, `hrt_mutex_try_lock`, `hrt_mutex_unlock`.
-- Owner-tracked, non-recursive, task-context-only mutual exclusion primitive.
-- Unlock performs direct handoff to one waiter when contention exists.
-- Current implementation does **not** provide priority inheritance or timed lock.
 
-### Message Queues
-- `hrt_queue_init`, `hrt_queue_send`, `hrt_queue_recv`, `hrt_queue_try_send`, `hrt_queue_try_recv`.
-- Fixed-size items, copy-based FIFO. See [QUEUES.md](docs/QUEUES.md).
+- `hrt_mutex_init`, `hrt_mutex_lock`, `hrt_mutex_try_lock`, `hrt_mutex_unlock`
 
-### Scheduling Flow
-![scheduling_flow.png](docs/images/scheduling_flow.png)
+Mutexes are task-context-only, non-recursive, and owner-tracked. The current implementation has no priority inheritance or timed lock.
 
-Tick (ISR/signal) -> hrt_tick_from_isr():
-- g_tick++
-- wake any SLEEP tasks whose wake_tick ⇐ now
-- hrt__pend_context_switch() (set resched flag)
+### Message queues
 
-Scheduler loop (port):
-- if resched flag:
-  -  next = hrt__pick_next_ready()
-  -  swapcontext/PendSV to next task
+- `hrt_queue_init`
+- blocking and non-blocking send/receive
+- non-blocking ISR send/receive
 
-Task-level yield/sleep:
-- mark state (READY→queue or SLEEP)
-- hrt__pend_context_switch()
-- hrt_port_yield_to_scheduler() (safe handoff from task ctx)
+Queue items are copied with `memcpy` while the queue operation holds the port critical section. Keep items small or enqueue pointers/indices whose lifetime is managed by the application.
 
----
+## Timing measurements
 
-## Statistics
+[STATISTICS.md](docs/STATISTICS.md) contains measurements collected on an STM32H755 Cortex-M7 setup. Those values characterize that recorded configuration and workload; they are not general worst-case execution-time guarantees for every application, interrupt layout, build, or memory configuration.
 
-See [STATISTICS.md](docs/STATISTICS.md) for detailed information on timing and tests collected for **HardRT v0.4.0**. 
+## License
 
-These results provide a solid baseline for further optimization and for documenting real-time behavior guarantees. Fundamental deterministic behavior remains identical to previous versions.
-
----
-## 📜 License
-Apache License 2.0 — see [LICENSE](LICENSE).
+Apache License 2.0. See [LICENSE](LICENSE).

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,17 +1,40 @@
-Added
-- Message queues: fixed-size, copy-based FIFO with blocking, non-blocking and ISR support
-- Mutexes: owner-tracked, non-recursive mutual exclusion with FIFO waiter queue and direct handoff on unlock
-- Mutex examples: new C and C++ examples demonstrating mutual exclusion in `examples/mutex_basic[_cpp]`
-- POSIX example runner: `scripts/run-all-examples.sh` for automated verification of all POSIX-compatible examples
-- Task deletion API: `hrt_task_delete()` for explicit task removal; also automatically called when a task returns
-- Time helper API: `hrt_now_ms()` for easy millisecond-based time tracking
-- Comprehensive POSIX tests for queues, mutexes, and new time/task APIs
-- C++ wrapper API (`hardrtpp.hpp`) providing idiomatic C++ access to HardRT primitives
-- C++ example applications demonstrating mixed C/C++ usage
+# HardRT v0.4.0 Release Notes
 
-Notes
-- Core HardRT kernel remains pure C
-- C++ support is optional and zero-cost when unused
-- Mutexes are task-context only and currently do not implement priority inheritance
-- ABI/API compatibility with v0.3.0 is preserved
-- Validated on Ubuntu 22.04 / 24.04 / latest / stm32h755zi-q, failure detected on debian 13 (GCC 14 + glibc 2.41).
+## Added
+
+- Fixed-size, copy-based message queues with blocking, non-blocking, and ISR operations.
+- Owner-tracked, non-recursive mutexes with FIFO waiter queues and direct handoff.
+- C and C++ mutex examples under `examples/mutex_basic` and `examples/mutex_basic_cpp`.
+- `scripts/run-all-examples.sh` for POSIX-compatible example verification.
+- `hrt_task_delete()` for explicit task removal; task trampolines also call it when a task returns.
+- `hrt_now_ms()` for millisecond conversion from the configured tick rate.
+- Expanded POSIX tests for queues, mutexes, task return, deletion, external tick mode, and time helpers.
+- Optional header-only C++17 wrapper in `cpp/hardrtpp.hpp`.
+- C++ examples for tasks, semaphores, counting semaphores, mutexes, and queues.
+
+## Current behavior and limitations
+
+- The kernel core remains C and uses static allocation.
+- The C++ wrapper is optional at the API level, although the current root CMake project enables the C++ language during every configure.
+- Mutexes are task-context-only and do not implement priority inheritance or timed lock.
+- Blocking semaphore, mutex, and queue operations have no timeout.
+- The POSIX port uses Linux/glibc `ucontext` and cooperative context handoff at HardRT scheduling points.
+- The current `HRT_SCHED_RR` implementation still selects from priority queues; it is not global priority-independent round-robin.
+- `hrt_sleep(0)` sleeps for one tick in v0.4.0. Use `hrt_yield()` for an immediate scheduling point.
+- ISR `need_switch` outputs report that a waiter was awakened; they do not currently perform a higher-priority comparison.
+
+## Compatibility
+
+HardRT v0.4.0 does **not** make an ABI-compatibility guarantee with v0.3.x.
+
+Public synchronization structures are concrete types. In particular, the semaphore structure changed to include counting-semaphore state, which can change size and member offsets for already compiled consumers. Applications should rebuild against the v0.4.0 headers and library together.
+
+Source compatibility is best effort for the documented application-facing APIs, but internal names and public structure layouts are not frozen before 1.0.0.
+
+## Validation scope
+
+The release has been exercised on Ubuntu 22.04, Ubuntu 24.04, GitHub-hosted Linux environments, and STM32H755ZI-Q Cortex-M7 validation setups.
+
+A POSIX test-suite failure has been observed on Debian 13 with GCC 14 and glibc 2.41. The POSIX port is intended for logic testing and is not claimed to support every libc or Unix platform.
+
+Timing values recorded in `docs/STATISTICS.md` apply to the documented hardware, build, instrumentation, and workload. They are measurements rather than universal worst-case latency guarantees.

--- a/cpp/hardrtpp.hpp
+++ b/cpp/hardrtpp.hpp
@@ -29,8 +29,10 @@ namespace hardrt {
          * @param fn     Pointer to the task function.
          * @param arg    User argument passed to the task function.
          * @param prio   Task priority.
-         * @param slice  Timeslice in ticks (0 for default).
-         * @return 0 on success, or a negative error code on failure.
+         * @param slice  Timeslice in ticks; zero creates a cooperative task.
+         * @return Non-negative task ID on success, or a negative error code.
+         * @note Because an explicit attribute object is passed to the C API, a
+         *       zero slice does not request the system default.
          */
         template <size_t StackWords = 1024, int Tag = 0>
         static int create(const hrt_task_fn fn, void* arg, const hrt_prio_t prio, const uint16_t slice = 0) {
@@ -47,8 +49,8 @@ namespace hardrt {
          * @param stack  Pointer to the beginning of the stack array (uint32_t).
          * @param words  Size of the stack in 32-bit words.
          * @param prio   Task priority.
-         * @param slice  Timeslice in ticks (0 to use system default).
-         * @return 0 on success.
+         * @param slice  Timeslice in ticks; zero creates a cooperative task.
+         * @return Non-negative task ID on success, or a negative error code.
          */
         static int create_with_stack(const hrt_task_fn fn, void* arg, uint32_t* stack, const size_t words,
                                      const hrt_prio_t prio, const uint16_t slice = 0) {
@@ -58,14 +60,15 @@ namespace hardrt {
 
         /**
          * @brief Put the current task to sleep for a specified duration.
-         * @param ms Duration in milliseconds.
+         * @param ms Duration in milliseconds. In v0.4.0, zero sleeps for one tick.
          */
         static void sleep(uint32_t ms) {
             hrt_sleep(ms);
         }
 
         /**
-         * @brief Yield the CPU to another task of the same or higher priority.
+         * @brief Yield the CPU, moving the current READY task to the tail of its
+         * priority queue and refreshing its configured slice.
          */
         static void yield() {
             hrt_yield();
@@ -100,9 +103,11 @@ namespace hardrt {
         /**
          * @brief Initialize the RTOS kernel.
          *
-         * Must be called exactly once before any other RTOS function.
+         * Applications should call this once before creating tasks or starting
+         * the scheduler. The v0.4.0 C implementation returns zero and does not
+         * validate repeated initialization or lifecycle ordering.
          * @param cfg Configuration structure (tick rate, scheduling policy, etc.).
-         * @return 0 on success, or a negative error code on failure.
+         * @return The value returned by hrt_init().
          */
         static int init(const hrt_config_t& cfg) {
             return hrt_init(&cfg);
@@ -111,15 +116,15 @@ namespace hardrt {
         /**
          * @brief Start the RTOS scheduler.
          *
-         * This function normally never returns. It transfers control to the highest
-         * priority task created.
+         * This function normally does not return on Cortex-M. The null port
+         * returns without running tasks.
          */
         static void start() {
             hrt_start();
         }
 
         /**
-         * @brief Get the elapsed system ticks since boot.
+         * @brief Get the elapsed system ticks since initialization.
          * @return Current tick count.
          */
         static uint32_t tick_now() {
@@ -127,8 +132,8 @@ namespace hardrt {
         }
 
         /**
-         * @brief Get the elapsed system time in milliseconds since boot.
-         * @return Milliseconds since System::init().
+         * @brief Get the elapsed system time in milliseconds.
+         * @return Milliseconds derived from the current tick and tick rate.
          */
         static uint32_t now_ms() {
             return hrt_now_ms();
@@ -143,7 +148,7 @@ namespace hardrt {
         }
 
         /**
-         * @brief Get the RTOS version as a packed 32-bit integer.
+         * @brief Get the RTOS version as a packed integer.
          * @return Packed version (0xMMmmPP).
          */
         static uint32_t version_u32() {
@@ -168,15 +173,14 @@ namespace hardrt {
     };
 
     /**
-     * @brief Object-oriented wrapper for binary semaphores.
-     *
-     * Used for task synchronization and resource protection.
+     * @brief Object-oriented wrapper for binary or counting semaphores.
      */
     class Semaphore {
     public:
         /**
          * @brief Initialize a semaphore. Binary by default, counting if max_count > 1.
-         * @param init Initial state: 1 (available/given), 0 (unavailable/taken).
+         * @param init Initial token count, clamped by the C implementation.
+         * @param max_count Maximum token count.
          */
         explicit Semaphore(unsigned init = 0, uint8_t max_count = 1) {
             if (max_count <= 1) {
@@ -188,10 +192,8 @@ namespace hardrt {
         }
 
         /**
-         * @brief Take (wait for) the semaphore.
-         *
-         * Blocks the calling task if the semaphore is not available.
-         * @return 0 on success.
+         * @brief Take the semaphore, blocking if no token is available.
+         * @return 0 after the semaphore has been acquired.
          */
         int take() {
             return hrt_sem_take(&_sem);
@@ -199,28 +201,26 @@ namespace hardrt {
 
         /**
          * @brief Attempt to take the semaphore without blocking.
-         * @return 0 if taken successfully, -1 if it was already unavailable.
+         * @return 0 on success, -1 when unavailable.
          */
         int try_take() {
             return hrt_sem_try_take(&_sem);
         }
 
         /**
-         * @brief Give (release) the semaphore.
-         *
-         * Wakes one waiting task according to the semaphore handoff policy.
-         * @return 0 on success.
+         * @brief Give the semaphore.
+         * @return 0.
+         * @note The current implementation yields when it wakes a waiter.
          */
         int give() {
             return hrt_sem_give(&_sem);
         }
 
         /**
-         * @brief Give (release) the semaphore from an Interrupt Service Routine (ISR).
-         *
-         * Special version to be used in hardware interrupts.
-         * @param need_switch [out] Set to 1 if a context switch is required after the ISR.
-         * @return 0 on success.
+         * @brief Give the semaphore from an ISR.
+         * @param need_switch Set to 1 when any waiter is awakened. In v0.4.0
+         *        this is not a higher-priority comparison.
+         * @return 0.
          */
         int give_from_isr(int& need_switch) {
             return hrt_sem_give_from_isr(&_sem, &need_switch);
@@ -231,13 +231,13 @@ namespace hardrt {
     };
 
     /**
-     * @brief C++ wrapper for HardRT queues.
+     * @brief C++ wrappers for fixed-capacity, copy-based HardRT queues.
      *
-     * HardRT queues are fixed-capacity and copy items into a user-provided
-     * storage buffer (no malloc). This wrapper provides two options:
+     * - QueueRef<T>: binds to externally provided storage.
+     * - StaticQueue<T, Capacity>: owns storage sized at compile time.
      *
-     * - QueueRef<T>: bind to externally provided storage
-     * - StaticQueue<T, Capacity>: owns a static buffer sized at compile-time
+     * The C implementation copies T with memcpy. Use types that are safe to
+     * copy byte-for-byte. The v0.4.0 wrapper does not enforce trivial copyability.
      */
     template <typename T>
     class QueueRef {
@@ -248,9 +248,8 @@ namespace hardrt {
 
         /**
          * @brief Initialize a queue using external storage.
-         *
-         * @param storage   Byte buffer large enough for (capacity * sizeof(T)).
-         * @param capacity  Number of T elements.
+         * @param storage Byte buffer large enough for capacity * sizeof(T).
+         * @param capacity Number of T elements.
          */
         void init(void* storage, uint16_t capacity) {
             hrt_queue_init(&_q, storage, capacity, sizeof(T));
@@ -327,6 +326,9 @@ namespace hardrt {
         hrt_queue_t _q{};
     };
 
+    /**
+     * @brief C++ wrapper for the current owner-tracked, non-recursive mutex.
+     */
     class Mutex {
     public:
         Mutex() {

--- a/docs/API_C.md
+++ b/docs/API_C.md
@@ -1,66 +1,124 @@
-## 🧠 API Overview (C)
+# C API Overview
 
-This page summarizes the public C API available in HardRT v0.4.0. See `inc/hardrt.h` for authoritative declarations.
+This page summarizes the public C surface available in HardRT v0.4.0. It describes the current implementation on `develop`; roadmap items and proposed v0.5.0 behavior are not presented as available APIs.
 
-### Types
+## Core types
 
 ```c
-/* Task function signature */
-typedef void (*hrt_task_fn)(void*);
+typedef void (*hrt_task_fn)(void *arg);
 
-/* Task state (internal for reference) */
-typedef enum { HRT_READY=0, HRT_SLEEP, HRT_BLOCKED, HRT_UNUSED } hrt_state_t;
-
-/* Scheduler policies */
 typedef enum {
-    HRT_SCHED_PRIORITY,     /* strict priority, FIFO within class */
-    HRT_SCHED_RR,           /* round-robin across all READY tasks */
-    HRT_SCHED_PRIORITY_RR   /* priority + RR within the same class */
+    HRT_READY = 0,
+    HRT_SLEEP,
+    HRT_BLOCKED,
+    HRT_UNUSED
+} hrt_state_t;
+
+typedef enum {
+    HRT_SCHED_PRIORITY = 0,
+    HRT_SCHED_RR,
+    HRT_SCHED_PRIORITY_RR
 } hrt_policy_t;
 
-/* Priority levels (0 is highest) */
-typedef enum { HRT_PRIO0=0, HRT_PRIO1, /* ... */ HRT_PRIO11 } hrt_prio_t;
+typedef enum {
+    HRT_TICK_SYSTICK = 0,
+    HRT_TICK_EXTERNAL = 1
+} hrt_tick_source_t;
 
-/* Init-time configuration */
 typedef struct {
-    uint32_t     tick_hz;
-    hrt_policy_t policy;
-    uint16_t     default_slice;
-    uint32_t     core_hz;
+    uint32_t          tick_hz;
+    hrt_policy_t      policy;
+    uint16_t          default_slice;
+    uint32_t          core_hz;
     hrt_tick_source_t tick_src;
 } hrt_config_t;
 
-/* Per-task attributes passed at creation */
 typedef struct {
     hrt_prio_t priority;
     uint16_t   timeslice;
 } hrt_task_attr_t;
 ```
 
-### Version and port identity
+Priority `0` is the highest priority. The usable range is limited by `HARDRT_MAX_PRIO`, even though symbolic values through `HRT_PRIO11` are declared.
+
+## Version and port identity
 
 ```c
-const char* hrt_version_string(void);  /* e.g. "0.4.0" */
-unsigned    hrt_version_u32(void);     /* (maj<<16)|(min<<8)|patch */
-const char* hrt_port_name(void);       /* e.g. "posix" or "null" */
-int         hrt_port_id(void);         /* 0=null, 1=posix, ... */
+const char *hrt_version_string(void);
+unsigned    hrt_version_u32(void);
+const char *hrt_port_name(void);
+int         hrt_port_id(void);
 ```
 
-### Core lifecycle
+For v0.4.0, `hrt_version_u32()` encodes the version as `(major << 16) | (minor << 8) | patch`.
+
+## Kernel lifecycle
 
 ```c
-int  hrt_init(const hrt_config_t* cfg);
-int  hrt_create_task(hrt_task_fn fn, void* arg,
-                     uint32_t* stack_words, size_t n_words,
-                     const hrt_task_attr_t* attr);
+int  hrt_init(const hrt_config_t *cfg);
+int  hrt_create_task(hrt_task_fn fn,
+                     void *arg,
+                     uint32_t *stack_words,
+                     size_t n_words,
+                     const hrt_task_attr_t *attr);
 void hrt_start(void);
 ```
 
-- `hrt_init` initializes the kernel, applies scheduler configuration, and starts the port tick when the selected tick source requires it.
-- `hrt_create_task` registers a static task using the provided stack buffer. Minimum stack constraints depend on the port.
-- `hrt_start` enters the scheduler loop. On the null port it returns immediately.
+### `hrt_init`
 
-### Control and time
+`hrt_init(NULL)` selects these defaults:
+
+- tick frequency: `1000 Hz`;
+- policy: `HRT_SCHED_PRIORITY_RR`;
+- default slice: `5` ticks;
+- tick source: `HRT_TICK_SYSTICK`.
+
+With an explicit configuration:
+
+- `tick_hz == 0` becomes `1000`;
+- `default_slice == 0` becomes `5`;
+- `policy` and `tick_src` are stored without validation;
+- the port tick-start hook is called during initialization.
+
+The current implementation always returns `0`. It does not reject repeated initialization or invalid lifecycle ordering. Applications should call it once before creating tasks or starting the scheduler.
+
+### `hrt_create_task`
+
+The function returns a non-negative task ID on success and `-1` on the checked failure paths.
+
+Current requirements:
+
+- `fn` is non-null;
+- `stack_words` is non-null;
+- `n_words >= 64`;
+- a task slot is available.
+
+If `attr == NULL`, the task uses priority `HRT_PRIO1` and the current default slice. If an attribute object is supplied, its `timeslice` is used exactly; `timeslice == 0` makes that task cooperative.
+
+The CMake build reserves one additional slot for the idle task by defining `HARDRT_MAX_TASKS` as `HARDRT_CFG_MAX_TASKS + 1`.
+
+### `hrt_start`
+
+The function requests initial scheduling and enters the selected port scheduler.
+
+- Cortex-M does not return under normal operation.
+- POSIX returns only through test hooks in the test build.
+- The null port returns without running tasks.
+
+## Scheduling policies in v0.4.0
+
+Ready tasks are stored in one FIFO queue per priority. The scheduler always scans priorities from highest to lowest and selects from the first non-empty queue.
+
+- `HRT_SCHED_PRIORITY` does not perform tick-driven slice accounting.
+- `HRT_SCHED_RR` performs slice accounting, but selection still respects priority queues.
+- `HRT_SCHED_PRIORITY_RR` also performs slice accounting and rotates tasks within their priority class.
+- `timeslice == 0` disables tick-driven rotation for that task.
+
+Therefore, the current `HRT_SCHED_RR` implementation is not a single global priority-independent round-robin queue.
+
+A slice is measured in ticks. A task whose slice expires is requeued when execution returns to the scheduler through a safe scheduling path.
+
+## Task control and time
 
 ```c
 void     hrt_sleep(uint32_t ms);
@@ -70,124 +128,156 @@ uint32_t hrt_tick_now(void);
 uint32_t hrt_now_ms(void);
 ```
 
-- `hrt_sleep` puts the current task to sleep for at least `ms` milliseconds.
-- `hrt_yield` voluntarily gives up the CPU to the next ready task of the same or higher priority.
-- `hrt_task_delete` removes the current task from the scheduler.
-- `hrt_tick_now` returns the current system tick count.
-- `hrt_now_ms` returns the current system time in milliseconds.
+### `hrt_sleep`
 
-**Note:** If a task returns from its entry function, `hrt_task_delete` is called automatically and the task is removed from the scheduler.
+Milliseconds are converted with ceiling division:
 
-### Runtime tuning
-
-```c
-void hrt_set_policy(hrt_policy_t p);
-void hrt_set_default_timeslice(uint16_t t);
+```text
+ceil(ms * tick_hz / 1000)
 ```
 
-- Changing policy affects scheduling decisions from the next scheduling point onward.
-- Changing the default slice affects tasks created after the change. Existing tasks keep their configured timeslice.
+Positive durations shorter than one tick sleep for one tick. In v0.4.0, `hrt_sleep(0)` also sleeps for one tick rather than behaving like `hrt_yield()`.
 
-### Round-robin semantics
+### `hrt_yield`
 
-- When policy is `HRT_SCHED_RR` or `HRT_SCHED_PRIORITY_RR` and a task has a non-zero `timeslice`, the running task’s quantum is decremented on tick accounting.
-- When the quantum reaches zero, the scheduler reschedule path is pended and the actual rotation happens at a safe scheduling point.
-- Tasks with `timeslice == 0` are cooperative within their priority class and will not be rotated by time slicing.
+The current task is moved to the tail of its priority queue, its configured slice is refreshed, rescheduling is requested, and task context is transferred to the port scheduler.
 
-### Semaphores
+### `hrt_task_delete`
 
-The kernel provides a minimal semaphore primitive in `hardrt_sem.h`.
+The current non-idle task is marked `HRT_UNUSED` and yields to the scheduler. Both reference task trampolines call this function when a task entry returns.
 
-```c
-void hrt_sem_init(hrt_sem_t* s, unsigned init);
-void hrt_sem_init_counting(hrt_sem_t* s, unsigned init, uint8_t max_count);
+### Time queries
 
-int  hrt_sem_take(hrt_sem_t* s);
-int  hrt_sem_try_take(hrt_sem_t* s);
-int  hrt_sem_give(hrt_sem_t* s);
-int  hrt_sem_give_from_isr(hrt_sem_t* s, int* need_switch);
-```
+`hrt_tick_now()` returns the wrapping 32-bit tick count. `hrt_now_ms()` computes `(ticks * 1000) / tick_hz` using a 64-bit intermediate.
 
-Notes:
-- Binary semaphores saturate at `1`.
-- Counting semaphores saturate at `max_count`.
-- Waiters are queued FIFO.
-- `hrt_sem_give_from_isr()` is supported.
-- Semaphores are **not owner-tracked**. For mutual exclusion, prefer `hrt_mutex_t`.
-
-See `docs/SEMAPHORES.md` for details.
-
-### Mutexes
-
-The kernel provides a dedicated mutex primitive in `hardrt_mutex.h`.
+## Runtime tuning
 
 ```c
-#define HRT_MUTEX_NO_OWNER (-1)
-
-typedef struct {
-    volatile uint8_t locked;
-    int16_t owner;
-    uint8_t q[HARDRT_MAX_TASKS];
-    uint8_t head;
-    uint8_t tail;
-    uint8_t count_wait;
-} hrt_mutex_t;
-
-void hrt_mutex_init(hrt_mutex_t* m);
-int  hrt_mutex_lock(hrt_mutex_t* m);
-int  hrt_mutex_try_lock(hrt_mutex_t* m);
-int  hrt_mutex_unlock(hrt_mutex_t* m);
+void hrt_set_policy(hrt_policy_t policy);
+void hrt_set_default_timeslice(uint16_t ticks);
 ```
 
-Notes:
-- Mutexes are **owner-tracked** and **non-recursive**.
-- `hrt_mutex_lock()` blocks until ownership is acquired.
-- `hrt_mutex_unlock()` may directly hand ownership to the next waiter.
-- Waiters are queued FIFO.
-- Mutex calls are **task-context only**. There is no ISR mutex API.
-- The current implementation does **not** include timed lock, recursive mutexes, or priority inheritance.
+`hrt_set_policy()` stores the new value without validation or rebuilding ready queues. The next scheduling decision uses the new value.
 
-See `docs/MUTEXES.md` for full semantics.
+`hrt_set_default_timeslice()` affects tasks created later with `attr == NULL`. Existing task configurations are unchanged. Setting the default to zero makes later default-created tasks cooperative.
 
-### Queues
-
-The kernel provides fixed-size copy-based message queues in `hardrt_queue.h`.
+## Tick API
 
 ```c
-void hrt_queue_init(hrt_queue_t *q, void *storage, uint16_t capacity, size_t item_size);
-int  hrt_queue_send(hrt_queue_t *q, const void *item);
-int  hrt_queue_try_send(hrt_queue_t *q, const void *item);
-int  hrt_queue_try_send_from_isr(hrt_queue_t *q, const void *item, int *need_switch);
-int  hrt_queue_recv(hrt_queue_t *q, void *out);
-int  hrt_queue_try_recv(hrt_queue_t *q, void *out);
-int  hrt_queue_try_recv_from_isr(hrt_queue_t *q, void *out, int *need_switch);
-uint16_t hrt_queue_count(const hrt_queue_t *q);
+void hrt_tick_from_isr(void);
 ```
 
-### Minimal example
+This public function is only for `HRT_TICK_EXTERNAL`. It advances time through the core tick handler and internally requests rescheduling when a sleeper wakes or a slice expires.
+
+When the selected source is `HRT_TICK_SYSTICK`, the current implementation ignores calls to `hrt_tick_from_isr()`. Port-owned tick handlers call the private `hrt__tick_isr()` path instead.
+
+## Semaphores
+
+```c
+void hrt_sem_init(hrt_sem_t *sem, unsigned init);
+void hrt_sem_init_counting(hrt_sem_t *sem,
+                           unsigned init,
+                           uint8_t max_count);
+int  hrt_sem_take(hrt_sem_t *sem);
+int  hrt_sem_try_take(hrt_sem_t *sem);
+int  hrt_sem_give(hrt_sem_t *sem);
+int  hrt_sem_give_from_isr(hrt_sem_t *sem, int *need_switch);
+```
+
+Current behavior:
+
+- binary semaphores saturate at `1`;
+- counting semaphores saturate at `max_count`;
+- `max_count == 0` is changed to `1`;
+- waiters are stored FIFO;
+- a give with a waiter performs direct handoff and wakes exactly one task;
+- task-context give yields when it wakes a waiter;
+- ISR give sets `need_switch` to `1` whenever any waiter was awakened and pends rescheduling.
+
+In v0.4.0, `need_switch` does not indicate that the awakened task was specifically higher priority.
+
+See [SEMAPHORES.md](SEMAPHORES.md).
+
+## Mutexes
+
+```c
+void hrt_mutex_init(hrt_mutex_t *mutex);
+int  hrt_mutex_lock(hrt_mutex_t *mutex);
+int  hrt_mutex_try_lock(hrt_mutex_t *mutex);
+int  hrt_mutex_unlock(hrt_mutex_t *mutex);
+```
+
+Mutexes are owner-tracked, non-recursive, task-context-only, and use FIFO waiters with direct handoff. There is no timed lock, recursive mode, ISR API, or priority inheritance in v0.4.0.
+
+See [MUTEXES.md](MUTEXES.md).
+
+## Message queues
+
+```c
+void     hrt_queue_init(hrt_queue_t *queue,
+                        void *storage,
+                        uint16_t capacity,
+                        size_t item_size);
+int      hrt_queue_send(hrt_queue_t *queue, const void *item);
+int      hrt_queue_try_send(hrt_queue_t *queue, const void *item);
+int      hrt_queue_try_send_from_isr(hrt_queue_t *queue,
+                                     const void *item,
+                                     int *need_switch);
+int      hrt_queue_recv(hrt_queue_t *queue, void *out);
+int      hrt_queue_try_recv(hrt_queue_t *queue, void *out);
+int      hrt_queue_try_recv_from_isr(hrt_queue_t *queue,
+                                     void *out,
+                                     int *need_switch);
+uint16_t hrt_queue_count(const hrt_queue_t *queue);
+```
+
+Items are copied with `memcpy` while the port critical section is held. Blocking operations wait indefinitely. ISR variants are non-blocking, set `need_switch` whenever they wake any waiter, and pend rescheduling internally.
+
+See [QUEUES.md](QUEUES.md).
+
+## Minimal example
 
 ```c
 #include "hardrt.h"
 
-static uint32_t stackA[2048];
-static uint32_t stackB[2048];
+static uint32_t stack_a[2048];
+static uint32_t stack_b[2048];
 
-static void taskA(void*){ for(;;){ hrt_sleep(500); } }
-static void taskB(void*){ for(;;){ hrt_sleep(1000);} }
+static void task_a(void *arg) {
+    (void)arg;
+    for (;;) {
+        hrt_sleep(500);
+    }
+}
 
-int main(void){
-    hrt_config_t cfg = {
+static void task_b(void *arg) {
+    (void)arg;
+    for (;;) {
+        hrt_sleep(1000);
+    }
+}
+
+int main(void) {
+    const hrt_config_t cfg = {
         .tick_hz = 1000,
         .policy = HRT_SCHED_PRIORITY_RR,
         .default_slice = 5,
         .core_hz = 0,
         .tick_src = HRT_TICK_SYSTICK
     };
+
+    const hrt_task_attr_t a = {
+        .priority = HRT_PRIO0,
+        .timeslice = 0
+    };
+    const hrt_task_attr_t b = {
+        .priority = HRT_PRIO1,
+        .timeslice = 5
+    };
+
     hrt_init(&cfg);
-    hrt_task_attr_t p0 = { .priority = HRT_PRIO0, .timeslice = 0 };
-    hrt_task_attr_t p1 = { .priority = HRT_PRIO1, .timeslice = 5 };
-    hrt_create_task(taskA, 0, stackA, 2048, &p0);
-    hrt_create_task(taskB, 0, stackB, 2048, &p1);
+    hrt_create_task(task_a, NULL, stack_a, 2048, &a);
+    hrt_create_task(task_b, NULL, stack_b, 2048, &b);
     hrt_start();
 }
 ```

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -1,97 +1,176 @@
-# Build & Install
+# Build and Install
 
-This page covers configuring, building, installing, and consuming HardRT.
+This page describes the CMake behavior present in HardRT v0.4.0 on `develop`.
 
 ## Prerequisites
-- A C compiler (GCC/Clang)
-- CMake ≥ 3.16
-- Optional C++17 compiler if the C++ wrapper is enabled
 
-## Configure & build (terminal)
+The root project currently declares `C`, `CXX`, and `ASM` unconditionally:
+
+```cmake
+project(hardrt VERSION 0.4.0 LANGUAGES C CXX ASM)
+```
+
+A normal configure therefore requires:
+
+- a C compiler with C11 support;
+- a C++ compiler, even when `HARDRT_ENABLE_CPP=OFF`;
+- an assembler supported by the selected CMake generator/toolchain;
+- CMake 3.16 or newer.
+
+For Cortex-M builds, the supplied toolchain expects the GNU Arm Embedded tools. The exact compiler requirements are defined by `cmake/toolchains/arm-none-eabi.cmake`.
+
+## Configure and build the POSIX port
+
 ```bash
-# clone
-git clone https://github.com/<your-username>/hardrt.git
+git clone https://github.com/ExoSpaceLabs/hardrt.git
 cd hardrt
 
-# out-of-source build directory
-mkdir build && cd build
-
-# choose a port; `null` for a stub, `posix` for a hosted simulation
-cmake -DHARDRT_PORT=posix -DHARDRT_BUILD_EXAMPLES=ON ..
-
-# build the static library and examples
-cmake --build . --target two_tasks -j
-
-# run the example
-./examples/two_tasks/two_tasks
+cmake -S . -B build \
+  -DHARDRT_PORT=posix \
+  -DHARDRT_BUILD_EXAMPLES=ON
+cmake --build build -j
+./build/examples/two_tasks/two_tasks
 ```
 
-Expected output (excerpt on POSIX):
-```
-HardRT version: 0.4.0 (0x000400), port: posix (id=1)
-[A] tick count [0]
-[B] tock -----
-...
-```
+Representative output begins with the selected version and port. Task interleaving is dependent on task configuration and scheduling points and should not be treated as a fixed output transcript.
 
-> Tip: the `null` port is a stub. It doesn’t start a tick or switch contexts. `hrt_start()` returns immediately, so tasks do not run there.
+The POSIX port requires Linux/glibc `ucontext`. It is intended for logic and scheduler testing rather than timing validation.
 
-## Building tests (POSIX)
-The POSIX test suite builds as a single executable `hardrt_tests`.
+## Build and run tests
+
 ```bash
-cmake -DHARDRT_PORT=posix -DHARDRT_BUILD_TESTS=ON ..
-cmake --build . --target hardrt_tests -j && ./hardrt_tests
+cmake -S . -B build-tests \
+  -DHARDRT_PORT=posix \
+  -DHARDRT_BUILD_TESTS=ON
+cmake --build build-tests --target hardrt_tests -j
+ctest --test-dir build-tests --output-on-failure
 ```
 
-For details, see `docs/TESTS_POSIX.md`.
+The test target is created only for the POSIX port. With another port selected, CMake reports that the runtime test target is skipped.
+
+See [TESTS_POSIX.md](TESTS_POSIX.md).
 
 ## CMake options
-| Option                  | Default | Description                                                                             |
-|-------------------------|---------|-----------------------------------------------------------------------------------------|
-| `HARDRT_PORT`           | `null`  | Select build port: `null`, `posix`, or `cortex_m`                                      |
-| `HARDRT_ENABLE_CPP`     | `OFF`   | Build C++17 header-only wrapper (`hardrtpp`)                                            |
-| `HARDRT_BUILD_EXAMPLES` | `ON`    | Build bundled demo projects                                                             |
-| `HARDRT_STRICT`         | `OFF`   | Enable strict warnings on POSIX builds                                                  |
-| `HARDRT_SANITIZE`       | `OFF`   | Enable ASan/UBSan on POSIX tests                                                        |
-| `HARDRT_STALL_ON_ERROR` | `OFF`   | Stalls in an infinite loop if an error occurs                                           |
-| `HARDRT_DEBUG`          | `OFF`   | Enables debug settings                                                                  |
-| `HARDRT_CFG_MAX_TASKS`  | `8`     | Maximum concurrent tasks supported by the kernel (maps to `HARDRT_MAX_TASKS`)          |
-| `HARDRT_CFG_MAX_PRIO`   | `4`     | Number of scheduler priority classes (0..N-1; maps to `HARDRT_MAX_PRIO`)               |
 
-Constraints and notes:
-- Priority levels have a symbolic cap of 12 in this release (`HRT_PRIO0..HRT_PRIO11`).
-- CMake validates at configuration time: `HARDRT_CFG_MAX_PRIO` must be in `[1, 12]` and `HARDRT_CFG_MAX_TASKS >= HARDRT_CFG_MAX_PRIO`.
-- `HARDRT_STALL_ON_ERROR` is disabled for the `posix` port as it breaks `ctest`.
+| Option | Default | Current behavior |
+|---|---:|---|
+| `HARDRT_PORT` | `null` | Selects `null`, `posix`, or `cortex_m`. |
+| `HARDRT_ENABLE_CPP` | `OFF` | Adds and installs the header-only `hardrtpp` interface target. The root configure still requires a C++ compiler because CXX is always enabled. |
+| `HARDRT_BUILD_EXAMPLES` | `ON` | Adds bundled example targets. C++ examples are added only when the wrapper is enabled. |
+| `HARDRT_BUILD_TESTS` | `ON` | Includes the test CMake file. A runnable `hardrt_tests` target is created only for `posix`. |
+| `HARDRT_STRICT` | `OFF` | Adds strict warning flags globally for POSIX builds. |
+| `HARDRT_SANITIZE` | `OFF` | Enables UndefinedBehaviorSanitizer for the POSIX test configuration. AddressSanitizer is deliberately not enabled because of `ucontext`. |
+| `HARDRT_STALL_ON_ERROR` | `OFF` | Publishes `HARDRT_STALL_ON_ERROR` as a compile definition. Keep this OFF for POSIX. The current POSIX warning path assigns a differently named CMake variable and does not reliably override an ON value. |
+| `HARDRT_DEBUG` | `OFF` | Publishes `HARDRT_DEBUG=0` or `1` and enables debug variables/checks in guarded code. |
+| `HARDRT_CFG_MAX_TASKS` | `8` | Number of application task slots requested through CMake. The build defines `HARDRT_MAX_TASKS` as this value plus one private idle slot. |
+| `HARDRT_CFG_MAX_PRIO` | `4` | Number of priority queues, with priority zero highest. Valid range is 1 through 12. |
 
-Examples:
-```bash
-cmake -DHARDRT_PORT=posix -DHARDRT_BUILD_TESTS=ON \
-      -DHARDRT_CFG_MAX_PRIO=12 -DHARDRT_CFG_MAX_TASKS=12 ..
-cmake --build . --target hardrt_tests -j && ./hardrt_tests
+## Configuration validation
 
-cmake -DHARDRT_PORT=posix -DHARDRT_ENABLE_CPP=ON ..
+CMake currently rejects configurations where:
+
+- `HARDRT_CFG_MAX_PRIO` is outside `[1, 12]`;
+- `HARDRT_CFG_MAX_TASKS < 1`;
+- `HARDRT_CFG_MAX_TASKS < HARDRT_CFG_MAX_PRIO`.
+
+For a CMake build with the defaults:
+
+```text
+HARDRT_CFG_MAX_TASKS = 8 application slots
+HARDRT_MAX_TASKS     = 9 total TCB/queue slots, including idle
 ```
 
-## Scripts
-The `scripts/` directory contains helper scripts for development and CI:
-- `scripts/run-all-examples.sh`: Configures, builds, and runs all POSIX-compatible examples under a timeout to verify basic functionality.
+This differs from compiling headers directly without the CMake-provided definition, where the fallback `HARDRT_MAX_TASKS` value is `8` total slots.
 
-## Install (optional)
-Install the library, headers, and CMake package files to a prefix:
+## Strict warnings and sanitizers
+
 ```bash
-cmake --install . --prefix "$PWD/install"
+cmake -S . -B build-strict \
+  -DHARDRT_PORT=posix \
+  -DHARDRT_BUILD_TESTS=ON \
+  -DHARDRT_STRICT=ON \
+  -DHARDRT_SANITIZE=ON
+cmake --build build-strict -j
+ctest --test-dir build-strict --output-on-failure
 ```
 
-This installs:
-- `libhardrt.a`
-- public headers from `inc/`
-- generated header `hardrt_version.h`
-- generated header `hardrt_port.h`
-- CMake package files under `lib/cmake/HardRT`
+`HARDRT_STRICT` currently enables:
+
+```text
+-Wall -Wextra -Wpedantic -Wconversion -Wcast-qual -Wshadow
+```
+
+`HARDRT_SANITIZE` currently enables:
+
+```text
+-fsanitize=undefined -fno-omit-frame-pointer
+```
+
+It does not enable AddressSanitizer.
+
+## C++ wrapper build
+
+```bash
+cmake -S . -B build-cpp \
+  -DHARDRT_PORT=posix \
+  -DHARDRT_ENABLE_CPP=ON
+cmake --build build-cpp -j
+```
+
+The C++ wrapper is an interface target and does not compile a separate wrapper library.
+
+## Null port
+
+```bash
+cmake -S . -B build-null -DHARDRT_PORT=null
+cmake --build build-null -j
+```
+
+The null port provides build-time stubs. It does not start a tick or transfer into task contexts. `hrt_start()` returns.
+
+## Cortex-M library build
+
+Use the supplied toolchain or an application-specific toolchain that provides the expected CPU and linker settings. The library port sources include ARM assembly and reference linker-provided RAM boundary symbols.
+
+The Cortex-M examples may have additional board/vendor dependencies. In particular, the timing example is not a generic host-build target.
+
+## Helper scripts
+
+- `scripts/run-all-examples.sh` configures, builds, and runs POSIX-compatible examples under timeouts.
+- `scripts/build-lib-posix.sh` configures a POSIX build, runs tests, and launches its example path.
+
+Inspect scripts before using them in a different build layout; they encode the repository's current target names and assumptions.
+
+## Install
+
+```bash
+cmake --install build --prefix "$PWD/build/install"
+```
+
+The install contains:
+
+- `libhardrt.a`;
+- public headers from `inc/`, excluding `hardrt_port_int.h`;
+- generated `hardrt_version.h` and `hardrt_port.h`;
+- CMake package files under `lib/cmake/HardRT`;
+- `hardrtpp.hpp` when `HARDRT_ENABLE_CPP=ON`.
 
 ## Consume from another CMake project
+
+C application:
+
 ```cmake
-find_package(HardRT REQUIRED)
+find_package(HardRT 0.4.0 REQUIRED)
 add_executable(app main.c)
 target_link_libraries(app PRIVATE HardRT::hardrt)
 ```
+
+C++ wrapper application, when the installed package includes it:
+
+```cmake
+find_package(HardRT 0.4.0 REQUIRED)
+add_executable(app main.cpp)
+target_link_libraries(app PRIVATE HardRT::hardrtpp)
+```
+
+Package compatibility is generated with CMake's `SameMajorVersion` policy. Since the project major version is zero, consumers should still review release notes for source, ABI, and behavioral changes between minor releases.

--- a/docs/CPP.md
+++ b/docs/CPP.md
@@ -1,65 +1,116 @@
-# C++ Wrapper (`hardrtpp.hpp`)
+# C++17 Wrapper (`hardrtpp.hpp`)
 
-HardRT provides an optional header-only C++17 wrapper in `cpp/hardrtpp.hpp`.
-It exposes thin, inline wrappers around the C API.
+HardRT v0.4.0 provides an optional header-only C++17 wrapper in `cpp/hardrtpp.hpp`. The wrapper is a thin layer over the C API and does not add dynamic allocation, exceptions, or a separate scheduler model.
 
-## Overview
+Enable it with:
 
-The wrapper currently provides:
-- `hardrt::System` for kernel init/start and version metadata
-- `hardrt::Task` for task creation and control
-- `hardrt::Semaphore` for binary and counting semaphores
-- `hardrt::Queue<T, Capacity>` for typed fixed-capacity queues
-- `hardrt::Mutex` for owner-tracked mutual exclusion
-
-## System Management
-
-```cpp
-#include <hardrtpp.hpp>
-
-hrt_config_t cfg{
-    1000,
-    HRT_SCHED_PRIORITY_RR,
-    5,
-    0,
-    HRT_TICK_SYSTICK
-};
-
-hardrt::System::init(cfg);
-hardrt::System::start();
-
-// Utilities
-uint32_t now = hardrt::System::now_ms();
-const char* ver = hardrt::System::version();
+```bash
+cmake -S . -B build \
+  -DHARDRT_PORT=posix \
+  -DHARDRT_ENABLE_CPP=ON
 ```
 
-## Task Management
+Downstream CMake projects link `HardRT::hardrtpp` when the package was built and installed with the wrapper enabled.
 
-### Automatic stack management
+## Available wrapper types
 
-The `Task::create<Size, Tag>` helper allocates a unique static stack per `<Size, Tag>` combination.
+- `hardrt::System`
+- `hardrt::Task`
+- `hardrt::Semaphore`
+- `hardrt::Mutex`
+- `hardrt::QueueRef<T>`
+- `hardrt::StaticQueue<T, Capacity>`
+
+There is no `hardrt::Queue<T, Capacity>` alias in v0.4.0.
+
+## System management
 
 ```cpp
 #include <hardrtpp.hpp>
 
-void worker(void* arg) {
+int main() {
+    const hrt_config_t cfg{
+        1000,
+        HRT_SCHED_PRIORITY_RR,
+        5,
+        0,
+        HRT_TICK_SYSTICK
+    };
+
+    const int rc = hardrt::System::init(cfg);
+    if (rc != 0) {
+        return rc;
+    }
+
+    const auto ticks = hardrt::System::tick_now();
+    const auto now_ms = hardrt::System::now_ms();
+    const char *version = hardrt::System::version_string();
+    const auto packed_version = hardrt::System::version_u32();
+    const char *port = hardrt::System::port_name();
+    const int port_id = hardrt::System::port_id();
+
+    (void)ticks;
+    (void)now_ms;
+    (void)version;
+    (void)packed_version;
+    (void)port;
+    (void)port_id;
+
+    hardrt::System::start();
+}
+```
+
+The current wrapper method is `version_string()`, not `version()`.
+
+`System::init()` forwards directly to `hrt_init()`. In the current C implementation, initialization returns `0` and does not validate repeated initialization or invalid lifecycle ordering.
+
+## Task management
+
+### Wrapper-owned static stack
+
+```cpp
+#include <hardrtpp.hpp>
+
+void worker(void *arg) {
     (void)arg;
     for (;;) {
         hardrt::Task::sleep(100);
     }
 }
 
-int main() {
-    hardrt::Task::create<1024, 0>(worker, nullptr, HRT_PRIO1);
-    hardrt::Task::create<2048, 1>(worker, nullptr, HRT_PRIO0);
+int create_tasks() {
+    const int first = hardrt::Task::create<1024, 0>(
+        worker, nullptr, HRT_PRIO1, 5);
+    const int second = hardrt::Task::create<2048, 1>(
+        worker, nullptr, HRT_PRIO0, 0);
+
+    return first < 0 ? first : second;
 }
 ```
 
-### Manual stack management
+Each unique `<StackWords, Tag>` template combination owns one function-local static stack array.
+
+The return value is the non-negative task ID returned by `hrt_create_task()`, or a negative failure result. It is not merely `0` on success.
+
+The `slice` argument is passed through an explicit `hrt_task_attr_t`:
+
+- `slice > 0` configures that many ticks per slice;
+- `slice == 0` creates a cooperative task.
+
+It does not request the system default slice. To use the C default-attribute path, call `hrt_create_task()` with `attr == nullptr` directly.
+
+### Application-owned stack
 
 ```cpp
-static uint32_t my_stack[512];
-hardrt::Task::create_with_stack(my_task, nullptr, my_stack, 512, HRT_PRIO1);
+alignas(8) static uint32_t worker_stack[512];
+
+const int id = hardrt::Task::create_with_stack(
+    worker,
+    nullptr,
+    worker_stack,
+    512,
+    HRT_PRIO1,
+    5);
 ```
 
 ### Task control
@@ -70,71 +121,98 @@ hardrt::Task::yield();
 hardrt::Task::delete_current();
 ```
 
-Note: If a task returns from its entry function, it is automatically deleted.
+In v0.4.0, `Task::sleep(0)` sleeps for one tick because it forwards to `hrt_sleep(0)`. Use `Task::yield()` for an immediate voluntary scheduling point.
+
+A task that returns from its entry function is deleted by the port trampoline.
 
 ## Semaphores
 
-The `hardrt::Semaphore` wrapper maps directly to `hrt_sem_t`.
-
 ```cpp
-hardrt::Semaphore sem(1);      // binary semaphore (available)
-hardrt::Semaphore slots(0, 5); // counting semaphore: 0..5 tokens
+hardrt::Semaphore ready(1);      // binary, initially available
+hardrt::Semaphore slots(0, 5);   // counting, range 0..5
 
-void worker(void*) {
-    sem.take();
-    // event/resource synchronization
-    sem.give();
+void consumer(void *arg) {
+    (void)arg;
+    ready.take();
+    ready.give();
 }
 ```
 
-Notes:
-- `give_from_isr()` is available on the wrapper.
-- For critical sections and ownership enforcement, use `hardrt::Mutex`.
+Available operations:
+
+```cpp
+sem.take();
+sem.try_take();
+sem.give();
+sem.give_from_isr(need_switch);
+```
+
+`give_from_isr()` forwards to the C API. In v0.4.0, `need_switch` becomes `1` whenever a waiter is awakened, regardless of the waiter's priority relative to the interrupted task.
 
 ## Mutexes
-
-The `hardrt::Mutex` wrapper maps directly to `hrt_mutex_t`.
 
 ```cpp
 hardrt::Mutex lock;
 
-void worker(void*) {
+void worker_with_lock(void *arg) {
+    (void)arg;
     for (;;) {
         lock.lock();
-        // critical section
+        /* Critical section. */
         lock.unlock();
         hardrt::Task::sleep(10);
     }
 }
 ```
 
-Semantics:
-- non-recursive
-- owner-tracked
-- task context only
-- no ISR API
-- no timed lock or priority inheritance in the current implementation
+The wrapper exposes `lock()`, `try_lock()`, and `unlock()`. The underlying mutex is non-recursive, owner-tracked, task-context-only, and has no timed lock or priority inheritance.
 
-## Queues
-
-The `Queue<T, Capacity>` wrapper provides a typed front-end over `hrt_queue_t`.
+## Queues with external storage
 
 ```cpp
-hardrt::Queue<int, 8> q;
+#include <array>
+#include <cstddef>
 
-void producer(void*) {
-    int value = 42;
-    q.send(value);
-}
+alignas(int) std::array<std::byte, 8 * sizeof(int)> storage{};
+hardrt::QueueRef<int> queue;
 
-void consumer(void*) {
-    int out{};
-    q.recv(out);
+void init_queue() {
+    queue.init(storage.data(), 8);
 }
 ```
 
-## Features
+`QueueRef<T>` stores the `hrt_queue_t` object but uses caller-provided item storage.
 
-- **Zero-overhead shape**: wrappers are inline and call into the C API directly.
-- **Typed convenience**: queue wrapper removes some boilerplate.
-- **No hidden allocation**: still fully static. The cult of heap abuse can stay elsewhere.
+## Queues with wrapper-owned storage
+
+```cpp
+hardrt::StaticQueue<int, 8> queue;
+
+void producer(void *arg) {
+    (void)arg;
+    const int value = 42;
+    queue.send(value);
+}
+
+void consumer(void *arg) {
+    (void)arg;
+    int value{};
+    queue.recv(value);
+}
+```
+
+Both queue wrappers expose:
+
+- `send` and `recv`;
+- `try_send` and `try_recv`;
+- `try_send_from_isr` and `try_recv_from_isr`;
+- `native_handle`.
+
+The C queue implementation copies objects as raw bytes with `memcpy`. Use queue element types that are safe to copy byte-for-byte, normally trivially copyable types. The v0.4.0 wrapper does not enforce that requirement with a `static_assert`.
+
+## Allocation and ownership
+
+- No wrapper performs heap allocation.
+- Task and queue storage remains static or caller-owned.
+- Wrapper objects must outlive every task that accesses their underlying C object.
+- Pointer-valued queue elements do not transfer ownership; the application remains responsible for the pointed-to storage.

--- a/docs/EXAMPLES_C.md
+++ b/docs/EXAMPLES_C.md
@@ -1,181 +1,186 @@
-## 🧪 Examples
+# Examples
 
-This guide summarizes the bundled examples and includes small usage snippets for features that are implemented in the codebase but do not yet have a dedicated standalone example application.
+This page summarizes the example applications bundled with HardRT v0.4.0 and shows small snippets using the current API.
 
-## Bundled repository examples
+## Bundled examples
 
-### C examples
+### C
+
 - `examples/two_tasks`
 - `examples/two_tasks_external`
 - `examples/sem_basic`
-- `examples/mutex_basic`
 - `examples/sem_counting`
+- `examples/mutex_basic`
 - `examples/queue_posix`
 - `examples/hardrt_h755_blinky`
 - `examples/hardrt_h755_demo`
 - `examples/hardrt_h755_dwt_timing`
 
-### C++ examples
+### C++
+
 - `examples/two_tasks_cpp`
 - `examples/sem_basic_cpp`
-- `examples/mutex_basic_cpp`
 - `examples/sem_counting_cpp`
+- `examples/mutex_basic_cpp`
 - `examples/queue_posix_cpp`
 - `examples/hardrt_h755_blinky_cpp`
 
-> Dedicated `mutex` example applications in C and C++ are available in `examples/mutex_basic` and `examples/mutex_basic_cpp`.
+C++ examples are added only when `HARDRT_ENABLE_CPP=ON`.
 
----
-
-## Build with the null port
+## Null-port example
 
 ```bash
-cmake -DHARDRT_PORT=null -DHARDRT_BUILD_EXAMPLES=ON ..
-cmake --build . --target two_tasks -j
-./examples/two_tasks/two_tasks
+cmake -S . -B build-null \
+  -DHARDRT_PORT=null \
+  -DHARDRT_BUILD_EXAMPLES=ON
+cmake --build build-null --target two_tasks -j
+./build-null/examples/two_tasks/two_tasks
 ```
 
-Expected output (program exits immediately; no live scheduling):
-```
-HardRT version: 0.4.0 (0x000400), port: null (id=0)
-```
+The null port does not start a tick or transfer into task contexts. `hrt_start()` returns, so the program prints its version/port information and exits without running the task bodies.
 
-Notes:
-- The null port doesn’t start a tick or switch contexts; `hrt_start()` returns.
-
-## Build with the POSIX port
+## POSIX two-task example
 
 ```bash
-cmake -DHARDRT_PORT=posix -DHARDRT_BUILD_EXAMPLES=ON ..
-cmake --build . --target two_tasks -j
-./examples/two_tasks/two_tasks
+cmake -S . -B build-posix \
+  -DHARDRT_PORT=posix \
+  -DHARDRT_BUILD_EXAMPLES=ON
+cmake --build build-posix --target two_tasks -j
+./build-posix/examples/two_tasks/two_tasks
 ```
 
-Expected output (excerpt; continues indefinitely):
-```terminaloutput
-HardRT version: 0.4.0 (0x000400), port: posix (id=1)
-[A] tick count [0]
-[B] tock -----
-[A] tick count [1]
-[A] tick count [2]
-[B] tock -----
-...
-```
+The POSIX port uses Linux/glibc `ucontext`. Tick accounting is signal-driven, but a running task returns to the scheduler only through a HardRT scheduling point.
 
-- Task A sleeps 500 ms; Task B sleeps 1000 ms. With `HRT_SCHED_PRIORITY_RR`, Task A has priority 0 and Task B priority 1, so Task A runs whenever READY.
+## Same-priority rotation
 
-## Seeing round-robin within a priority class
-
-To observe time-slice rotation, create two tasks with the same priority and non-zero `timeslice`:
+The current scheduler always selects the highest non-empty priority queue. To observe round-robin time slicing, use tasks at the same priority with non-zero slices:
 
 ```c
 #include "hardrt.h"
 #include <stdio.h>
 
-static uint32_t sa[2048], sb[2048];
-static void t1(void*){ for(;;){ puts("T1"); hrt_sleep(10); } }
-static void t2(void*){ for(;;){ puts("T2"); hrt_sleep(10); } }
+static uint32_t stack_a[2048];
+static uint32_t stack_b[2048];
 
-int main(void){
-    hrt_config_t cfg = {
+static void task_a(void *arg) {
+    (void)arg;
+    for (;;) {
+        puts("A");
+        hrt_sleep(10);
+    }
+}
+
+static void task_b(void *arg) {
+    (void)arg;
+    for (;;) {
+        puts("B");
+        hrt_sleep(10);
+    }
+}
+
+int main(void) {
+    const hrt_config_t cfg = {
         .tick_hz = 1000,
         .policy = HRT_SCHED_PRIORITY_RR,
         .default_slice = 5,
         .core_hz = 0,
         .tick_src = HRT_TICK_SYSTICK
     };
+    const hrt_task_attr_t attr = {
+        .priority = HRT_PRIO1,
+        .timeslice = 5
+    };
+
     hrt_init(&cfg);
-    hrt_task_attr_t a = { .priority = HRT_PRIO1, .timeslice = 5 };
-    hrt_create_task(t1, 0, sa, 2048, &a);
-    hrt_create_task(t2, 0, sb, 2048, &a);
+    hrt_create_task(task_a, NULL, stack_a, 2048, &attr);
+    hrt_create_task(task_b, NULL, stack_b, 2048, &attr);
     hrt_start();
 }
 ```
 
-## Mutex usage snippet in C
+A timeslice is measured in ticks. In the POSIX port, a CPU-bound task that never calls a HardRT scheduling point is not asynchronously swapped out by `SIGALRM`.
+
+## Mutex example in C
 
 ```c
 #include "hardrt.h"
 
-static hrt_mutex_t g_lock;
-static uint32_t s1[1024], s2[1024];
+static hrt_mutex_t lock;
+static uint32_t producer_stack[1024];
+static uint32_t consumer_stack[1024];
 
-static void producer(void*) {
+static void producer(void *arg) {
+    (void)arg;
     for (;;) {
-        hrt_mutex_lock(&g_lock);
-        /* critical section */
-        hrt_mutex_unlock(&g_lock);
+        hrt_mutex_lock(&lock);
+        /* Critical section. */
+        hrt_mutex_unlock(&lock);
         hrt_sleep(10);
     }
 }
 
-static void consumer(void*) {
+static void consumer(void *arg) {
+    (void)arg;
     for (;;) {
-        if (hrt_mutex_try_lock(&g_lock) == 0) {
-            /* short critical section */
-            hrt_mutex_unlock(&g_lock);
+        if (hrt_mutex_try_lock(&lock) == 0) {
+            /* Short critical section. */
+            hrt_mutex_unlock(&lock);
         }
         hrt_sleep(5);
     }
 }
 
 int main(void) {
-    hrt_config_t cfg = {
+    const hrt_config_t cfg = {
         .tick_hz = 1000,
         .policy = HRT_SCHED_PRIORITY_RR,
         .default_slice = 5,
         .core_hz = 0,
         .tick_src = HRT_TICK_SYSTICK
     };
+    const hrt_task_attr_t attr = {
+        .priority = HRT_PRIO1,
+        .timeslice = 5
+    };
 
     hrt_init(&cfg);
-    hrt_mutex_init(&g_lock);
-
-    hrt_task_attr_t p = { .priority = HRT_PRIO1, .timeslice = 5 };
-    hrt_create_task(producer, 0, s1, 1024, &p);
-    hrt_create_task(consumer, 0, s2, 1024, &p);
+    hrt_mutex_init(&lock);
+    hrt_create_task(producer, NULL, producer_stack, 1024, &attr);
+    hrt_create_task(consumer, NULL, consumer_stack, 1024, &attr);
     hrt_start();
 }
 ```
 
-Notes:
-- mutexes are task-context only
-- unlock must be performed by the owner
-- mutexes are non-recursive
+Mutexes are owner-tracked, non-recursive, and task-context-only. They have no timed lock or priority inheritance in v0.4.0.
 
-## Mutex usage snippet in C++
+## Mutex example in C++
 
 ```cpp
 #include <hardrtpp.hpp>
 
-static hardrt::Mutex g_lock;
+static hardrt::Mutex lock;
 
-static void worker(void*) {
+static void worker(void *arg) {
+    (void)arg;
     for (;;) {
-        g_lock.lock();
-        // critical section
-        g_lock.unlock();
+        lock.lock();
+        // Critical section.
+        lock.unlock();
         hardrt::Task::sleep(10);
     }
 }
 ```
 
-## External tick example (`two_tasks_external`)
+## External tick example
 
-This example is like `two_tasks` but HardRT time advances only when the application calls `hrt_tick_from_isr()`.
+`examples/two_tasks_external` initializes HardRT with `HRT_TICK_EXTERNAL`. The application-provided tick source calls `hrt_tick_from_isr()`; the POSIX port does not install its own periodic `SIGALRM` timer in this mode.
 
-Build and run on POSIX:
 ```bash
-cmake -DHARDRT_PORT=posix -DHARDRT_BUILD_EXAMPLES=ON ..
-cmake --build . --target two_tasks_external -j
-./examples/two_tasks_external/two_tasks_external
+cmake -S . -B build-external \
+  -DHARDRT_PORT=posix \
+  -DHARDRT_BUILD_EXAMPLES=ON
+cmake --build build-external --target two_tasks_external -j
+./build-external/examples/two_tasks_external/two_tasks_external
 ```
 
-Expected behavior:
-- Task A prints a counter roughly every 500 ms.
-- Task B prints a heartbeat roughly every 1000 ms.
-- The scheduler advances solely due to the external tick thread.
-
-Notes:
-- The example configures `hrt_config_t.tick_src = HRT_TICK_EXTERNAL`.
-- See also: [TICK_SOURCE.md](TICK_SOURCE.md).
+See [TICK_SOURCE.md](TICK_SOURCE.md) for the external-tick contract.

--- a/docs/INTRODUCTION.md
+++ b/docs/INTRODUCTION.md
@@ -1,51 +1,56 @@
-# 🫀 Introduction to HardRT
+# Introduction to HardRT
 
-HardRT — the **heartbeat of small embedded systems** — is a minimal, deterministic real‑time operating system
-written in C, designed for clarity, portability, and educational transparency.
+HardRT is a small real-time operating-system kernel written in C for static embedded systems and hosted logic testing.
 
----
+## Scope
 
-## 🔍 What Is an RTOS?
+HardRT v0.4.0 provides:
 
-A *Real‑Time Operating System (RTOS)* manages multiple concurrent tasks while guaranteeing predictable timing.
-It provides:
+- static task creation;
+- priority-based scheduling;
+- optional tick-driven rotation within priority classes;
+- sleep and yield operations;
+- binary and counting semaphores;
+- owner-tracked mutexes;
+- fixed-size message queues;
+- null, POSIX, and Cortex-M ports.
 
-- **Scheduling**: deciding which task runs next.
-- **Synchronization**: semaphores, mutexes, queues for communication.
-- **Timing control**: deterministic delays and periodic execution.
+It intentionally does not provide a heap, filesystem, networking stack, device HAL, process isolation, or general-purpose operating-system services.
 
-Unlike full OSes (Linux, Windows), an RTOS runs **without dynamic allocation** and often without file systems,
-focusing purely on *time‑critical task execution*.
+## Design goals
 
----
+| Goal | Current approach |
+|---|---|
+| Small core | Task, scheduler, timing, and synchronization logic are kept in a limited set of C sources. |
+| Static allocation | Task stacks and queue storage are supplied at build time or by the application. |
+| Port separation | Architecture-specific context, tick, critical-section, and idle operations live under `src/port/`. |
+| Inspectability | Public structures and much of the current kernel state are directly visible in the source. |
+| Bounded storage | Kernel arrays are sized by compile-time task and priority limits. |
 
-## ❤️ Why HardRT?
+Static allocation and bounded data structures do not by themselves prove an application's deadlines. Blocking semaphore, mutex, and queue calls may wait indefinitely, lower-priority tasks may be starved by continuously ready higher-priority work, and queue copy time depends on item size.
 
-HardRT was built to be *small, understandable, and verifiable*.
-Where many RTOS kernels grow opaque, HardRT keeps every subsystem visible in just a few C files.
+## Scheduling model
 
-| Feature           | Philosophy                                                    |
-|-------------------|---------------------------------------------------------------|
-| **Minimal Core**  | Just tasks, scheduler, and synchronization — no heap, no HAL. |
-| **Portable**      | Ports for POSIX and Cortex‑M are separate from kernel logic.  |
-| **Deterministic** | No unbounded loops or dynamic allocation in the kernel.       |
-| **Transparent**   | All state visible; no black‑box APIs.                         |
-| **Educational**   | Ideal for learning or building your own derived RTOS.         |
+Priority zero is highest. The current scheduler stores ready tasks in FIFO queues per priority and chooses from the highest non-empty queue.
 
----
+`HRT_SCHED_PRIORITY` does not use tick-driven slices. `HRT_SCHED_RR` and `HRT_SCHED_PRIORITY_RR` both account non-zero slices, but v0.4.0 still performs priority-ordered task selection in both modes.
 
-## ⚙️ Typical Use Cases
+The Cortex-M port can transfer context through PendSV after a tick or ISR requests rescheduling. The POSIX port uses signal-driven tick accounting but transfers task context only when the running task reaches a HardRT scheduling point.
 
-- Bare‑metal STM32 (Cortex‑M) firmware
-- Real‑time subsystems in hybrid Linux + MCU designs
-- Spacecraft housekeeping and payload task managers
-- Embedded vision and control loops on constrained devices
+## Typical uses
 
----
+- Cortex-M firmware with statically defined tasks;
+- subsystem and payload-control prototypes;
+- educational inspection of scheduler and synchronization mechanisms;
+- POSIX-hosted functional tests before target integration.
 
-## 📚 Further Reading
+The POSIX port is not a cycle-accurate or timing-accurate representation of Cortex-M execution.
 
-- [Build Guide](BUILD.md)
-- [C API Reference](API_C.md)
-- [Porting Guide](PORTING.md)
+## Further reading
+
+- [Build guide](BUILD.md)
+- [C API](API_C.md)
+- [C++ wrapper](CPP.md)
+- [Porting guide](PORTING.md)
+- [Tick sources](TICK_SOURCE.md)
 - [Roadmap](ROADMAP.md)

--- a/docs/MODULE_STATUS.md
+++ b/docs/MODULE_STATUS.md
@@ -1,22 +1,29 @@
-# Module status
+# Module Status
 
-Current components and their status.
+Current components in HardRT v0.4.0:
 
-- `inc/hardrt.h` — public C API (tasks, scheduler policy, time, config) [link](../inc/hardrt.h).
-- `inc/hardrt_sem.h` — semaphores, including counting mode and ISR-safe give [link](../inc/hardrt_sem.h).
-- `inc/hardrt_mutex.h` — mutex API with owner tracking and direct handoff [link](../inc/hardrt_mutex.h).
-- `inc/hardrt_queue.h` — fixed-size message queues with task and ISR try-operations [link](../inc/hardrt_queue.h).
-- `inc/hardrt_time.h` — tick ISR contract for ports (`hrt_tick_from_isr()`) [link](../inc/hardrt_time.h).
-- `cpp/hardrtpp.hpp` — C++17 object-oriented wrapper (implemented); see [docs/CPP.md](CPP.md).
-- Generated headers (installed alongside public headers):
-  - `hardrt_version.h` — project version (from CMake) [link](../inc/hardrt_version.h.in).
-  - `hardrt_port.h` — selected port identity (from CMake) [link](../inc/hardrt_port.h.in).
+- [`inc/hardrt.h`](../inc/hardrt.h): task, scheduler, configuration, time-query, version, port-identity, and currently exposed internal declarations.
+- [`inc/hardrt_time.h`](../inc/hardrt_time.h): public external-tick entry point `hrt_tick_from_isr()`.
+- [`inc/hardrt_sem.h`](../inc/hardrt_sem.h): binary/counting semaphores and ISR give.
+- [`inc/hardrt_mutex.h`](../inc/hardrt_mutex.h): owner-tracked non-recursive mutexes.
+- [`inc/hardrt_queue.h`](../inc/hardrt_queue.h): fixed-size copy-based queues with task and ISR operations.
+- [`inc/hardrt_port_int.h`](../inc/hardrt_port_int.h): non-installed port/core interface used by reference ports.
+- [`cpp/hardrtpp.hpp`](../cpp/hardrtpp.hpp): optional header-only C++17 wrappers.
+- generated `hardrt_version.h`: project version metadata.
+- generated `hardrt_port.h`: selected port identity.
 
-## Status notes
+## Current status notes
 
-- Priority enum provides 12 symbolic levels (`HRT_PRIO0..HRT_PRIO11`); effective range is `0..HARDRT_MAX_PRIO-1` per build config.
-- Max task/priority sizing is controlled at configure time; see `docs/BUILD.md` for `HARDRT_CFG_MAX_TASKS` and `HARDRT_CFG_MAX_PRIO`.
-- Mutexes are implemented as **non-recursive**, **task-context-only**, and **without priority inheritance** in the current release.
-- Dedicated example applications for mutexes in both C and C++ are available in `examples/mutex_basic[_cpp]`.
+- Version: `0.4.0`.
+- Priority values `HRT_PRIO0` through `HRT_PRIO11` are declared; the build-time usable range is `0` through `HARDRT_MAX_PRIO - 1`.
+- CMake defines `HARDRT_MAX_TASKS` as `HARDRT_CFG_MAX_TASKS + 1` to include the idle slot.
+- Ready queues are FIFO per priority. All current scheduler policies select the highest non-empty priority queue.
+- `HRT_SCHED_RR` and `HRT_SCHED_PRIORITY_RR` enable non-zero slice accounting; global priority-independent round-robin is not implemented.
+- The port-owned tick path calls private `hrt__tick_isr()`.
+- The public `hrt_tick_from_isr()` API is accepted only in `HRT_TICK_EXTERNAL` mode.
+- POSIX uses Linux/glibc `ucontext`, signal-driven tick accounting, and cooperative context handoff at HardRT scheduling points.
+- Mutexes are task-context-only and have no priority inheritance or timed lock.
+- Semaphores and queues expose ISR producer/consumer operations. Their `need_switch` output currently indicates that a waiter was awakened, not that a priority comparison selected immediate preemption.
+- Event flags, task notifications, and IPC timeout variants are not present in the current codebase.
 
-Current version: `0.4.0` (see `hrt_version_string()` and `hrt_version_u32()`).
+Bundled C and C++ examples are available for tasks, semaphores, counting semaphores, mutexes, and queues.

--- a/docs/MUTEXES.md
+++ b/docs/MUTEXES.md
@@ -1,23 +1,18 @@
-# 🔐 Mutexes
+# Mutexes
 
-HardRT provides a dedicated mutex primitive for mutual exclusion in task context.
+HardRT v0.4.0 provides an owner-tracked mutex for mutual exclusion in task context.
 
 ## Current semantics
 
 The current `hrt_mutex_t` implementation is:
-- **owner-tracked**
-- **non-recursive**
-- **FIFO for waiters**
-- **direct handoff on unlock**
-- **task-context only**
 
-The current implementation does **not** provide:
-- priority inheritance
-- recursive locking
-- timed lock / timeout API
-- ISR lock/unlock API
+- owner-tracked;
+- non-recursive;
+- FIFO for waiters;
+- direct-handoff on unlock;
+- task-context-only.
 
----
+It does not provide priority inheritance, recursive locking, timeout operations, or ISR lock/unlock APIs.
 
 ## API
 
@@ -26,90 +21,75 @@ The current implementation does **not** provide:
 
 #define HRT_MUTEX_NO_OWNER (-1)
 
-void hrt_mutex_init(hrt_mutex_t *m);
-int  hrt_mutex_lock(hrt_mutex_t *m);
-int  hrt_mutex_try_lock(hrt_mutex_t *m);
-int  hrt_mutex_unlock(hrt_mutex_t *m);
+void hrt_mutex_init(hrt_mutex_t *mutex);
+int  hrt_mutex_lock(hrt_mutex_t *mutex);
+int  hrt_mutex_try_lock(hrt_mutex_t *mutex);
+int  hrt_mutex_unlock(hrt_mutex_t *mutex);
 ```
 
-### Initialization
+## Initialization
 
 ```c
-hrt_mutex_t m;
-hrt_mutex_init(&m);
+hrt_mutex_t mutex;
+hrt_mutex_init(&mutex);
 ```
 
-After initialization:
-- `locked == 0`
-- `owner == HRT_MUTEX_NO_OWNER`
-- waiter queue is empty
+After initialization, the mutex is unlocked, its owner is `HRT_MUTEX_NO_OWNER`, and its waiter FIFO is empty.
 
-### `hrt_mutex_try_lock()`
+## Try lock
 
-Attempts to acquire the mutex without blocking.
+`hrt_mutex_try_lock()` attempts to acquire the mutex without blocking.
 
-Returns:
-- `0` on success
-- `-1` if already locked or the call is invalid for the current context
+- It returns `0` when the current task acquires ownership.
+- It returns `-1` when the mutex is already locked or the current context is invalid.
+- It returns `-1` when the current owner tries to acquire it again, because the mutex is non-recursive.
 
-If the current owner calls `try_lock()` again, the call fails because the mutex is non-recursive.
+## Blocking lock
 
-### `hrt_mutex_lock()`
+`hrt_mutex_lock()`:
 
-Blocks until the mutex becomes available.
+- acquires an unlocked mutex and records the current task as owner;
+- appends a contending task to the FIFO waiter queue and marks it blocked;
+- rejects recursive acquisition by the current owner.
 
-Behavior:
-- if unlocked, the current task becomes owner and returns `0`
-- if locked by another task, the caller is queued FIFO and moved to `HRT_BLOCKED`
-- if already owned by the caller, the call fails with `-1`
+When a blocked task resumes after direct handoff, it already owns the mutex.
 
-When a blocked task resumes after handoff, it already owns the mutex.
+There is no timed-lock variant in v0.4.0.
 
-### `hrt_mutex_unlock()`
+## Unlock
 
-Releases a mutex owned by the current task.
+Only the owning task may unlock.
 
-Behavior:
-- if there is no waiter, the mutex becomes unlocked and owner resets to `HRT_MUTEX_NO_OWNER`
-- if there is a waiter, ownership is transferred directly to the next waiter and that task is made READY
-- if called by a non-owner, the call fails with `-1`
+- With no waiter, the mutex becomes unlocked and the owner is reset.
+- With a waiter, ownership is transferred directly to the first FIFO waiter and that task is made ready.
+- A non-owner unlock returns `-1`.
 
----
+The current implementation yields after waking a waiter. Waiter selection is FIFO at the mutex, while final execution still follows the scheduler's priority-queue selection.
 
-## Scheduling behavior under contention
-
-When a task unlocks a contested mutex, HardRT performs **direct handoff**:
-1. dequeue one waiter
-2. transfer ownership to that waiter
-3. wake the waiter
-4. yield so the awakened task can run promptly under scheduler policy
-
-This avoids a release-then-race pattern and keeps handoff deterministic.
-
-Waiter order is FIFO at the mutex queue level. Final execution order still respects the scheduler's global priority policy.
-
----
-
-## Usage example (C)
+## C example
 
 ```c
 #include "hardrt.h"
 
 static hrt_mutex_t uart_lock;
+static uint32_t telemetry_stack[1024];
+static uint32_t log_stack[1024];
 
-static void telemetry_task(void*) {
+static void telemetry_task(void *arg) {
+    (void)arg;
     for (;;) {
         hrt_mutex_lock(&uart_lock);
-        /* write telemetry frame */
+        /* Write telemetry frame. */
         hrt_mutex_unlock(&uart_lock);
         hrt_sleep(20);
     }
 }
 
-static void log_task(void*) {
+static void log_task(void *arg) {
+    (void)arg;
     for (;;) {
         if (hrt_mutex_try_lock(&uart_lock) == 0) {
-            /* write log record */
+            /* Write log record. */
             hrt_mutex_unlock(&uart_lock);
         }
         hrt_sleep(5);
@@ -117,50 +97,58 @@ static void log_task(void*) {
 }
 
 int main(void) {
-    static uint32_t s1[1024], s2[1024];
-    hrt_config_t cfg = {
+    const hrt_config_t cfg = {
         .tick_hz = 1000,
         .policy = HRT_SCHED_PRIORITY_RR,
         .default_slice = 5,
         .core_hz = 0,
         .tick_src = HRT_TICK_SYSTICK
     };
+    const hrt_task_attr_t attr = {
+        .priority = HRT_PRIO1,
+        .timeslice = 5
+    };
 
     hrt_init(&cfg);
     hrt_mutex_init(&uart_lock);
-
-    hrt_task_attr_t p = { .priority = HRT_PRIO1, .timeslice = 5 };
-    hrt_create_task(telemetry_task, 0, s1, 1024, &p);
-    hrt_create_task(log_task, 0, s2, 1024, &p);
+    hrt_create_task(
+        telemetry_task,
+        NULL,
+        telemetry_stack,
+        1024,
+        &attr);
+    hrt_create_task(
+        log_task,
+        NULL,
+        log_stack,
+        1024,
+        &attr);
     hrt_start();
 }
 ```
 
-## Usage example (C++)
+## C++ example
 
 ```cpp
 #include <hardrtpp.hpp>
 
 static hardrt::Mutex uart_lock;
 
-static void task(void*) {
+static void worker(void *arg) {
+    (void)arg;
     for (;;) {
         uart_lock.lock();
-        // critical section
+        // Critical section.
         uart_lock.unlock();
         hardrt::Task::sleep(10);
     }
 }
 ```
 
----
-
-## Rules and caveats
+## Rules
 
 - Call mutex APIs only from task context.
-- Do not call mutex APIs from ISR.
-- Unlock must be performed by the owner.
+- Do not call mutex APIs from an ISR.
+- Unlock only from the owning task.
 - Do not attempt recursive locking.
-- Priority inversion mitigation is not yet implemented.
-
-For cases where ownership does not matter and ISR interaction does, use a semaphore instead.
+- Analyze priority inversion at the application level; v0.4.0 has no mitigation mechanism.

--- a/docs/PORTING.md
+++ b/docs/PORTING.md
@@ -1,221 +1,205 @@
 # HardRT Porting Guide
 
-This document describes how to port **HardRT** to a new architecture or execution environment.
-HardRT is intentionally split into a *portable core* and a *thin port layer*. The port layer is
-responsible only for time, interrupts, and context switching.
+This guide describes the port interface used by HardRT v0.4.0 on the `develop` branch. It documents the hooks that the current core and reference ports actually call. It does not describe planned v0.5.0 interfaces.
 
-If porting is performed on HardRT, **read this entire document before writing code**.
+HardRT separates the portable scheduler and synchronization code from architecture-specific tick, critical-section, stack, idle, and context-switch operations.
 
----
+## Current execution model
 
-## 1. Design Philosophy
+- The core owns task state and scheduling decisions.
+- A port owns stack-frame construction and context transfer.
+- Tick handlers update kernel state and request rescheduling; they do not directly run application task code.
+- Blocking APIs transfer control back to the scheduler from task context.
+- All storage is static.
 
-HardRT follows these rules:
+## Hooks implemented by a port
 
-- The **core scheduler is architecture-agnostic**
-- The **port owns all preemption and context switching**
-- ISRs must be **short, bounded, and defer work**
-- The scheduler **never blocks inside an ISR**
-- Context switches are **requested**, never forced
+### `void hrt_port_start_systick(uint32_t tick_hz)`
 
-If the port violates these, it may appear to work but will fail under load.
+Called by `hrt_init()`.
 
----
+Responsibilities:
 
-## 2. Required Port Hooks
+- start the port-owned periodic tick when `HRT_TICK_SYSTICK` is selected;
+- leave the periodic tick disabled when `HRT_TICK_EXTERNAL` is selected;
+- configure any context-switch interrupt required by the port;
+- make the requested tick frequency as accurate as the platform permits.
 
-Every port must implement the following hooks.
+The current `hrt_init()` call order invokes this hook before `hrt__init_idle_task()`. A port must not enter the scheduler or dispatch a task from this hook. The scheduler is entered later by `hrt_start()`.
 
-### 2.1 Initialization
+For a port-owned tick, the port handler calls the private core function `hrt__tick_isr()`. It does not call the public external-tick API.
 
-#### `void hrt_port_init(void);`
+### `void hrt_port_enter_scheduler(void)`
 
-- **Called by**: `hrt_init()`
-- **Context**: Thread
-- **ISR-safe**: No
-- **Purpose**:
-  - Initialize port state
-  - Prepare context switch mechanism
-  - Set interrupt priorities if required
+Called by `hrt_start()` after the core requests an initial reschedule.
 
-Must not enable periodic ticks.
+- Cortex-M enables interrupts, pends PendSV, and remains in its idle loop.
+- POSIX enters the hosted scheduler loop and transfers between `ucontext` objects.
+- The null port returns without running tasks.
 
----
+### `void hrt_port_yield_to_scheduler(void)`
 
-### 2.2 Tick Start
+Called from task context by sleep, yield, task deletion, and blocking synchronization paths.
 
-#### `void hrt_port_start_tick(uint32_t tick_hz);`
+- Cortex-M pends PendSV; the context change occurs through exception handling.
+- POSIX swaps from the current task context to the scheduler context with `SIGALRM` masked.
 
-- **Called by**: `hrt_start()`
-- **Context**: Thread
-- **ISR-safe**: No
-- **Purpose**:
-  - Start the system tick source
-  - Configure interrupt priorities
+This hook is task-context-only.
 
-Notes:
-- In **external tick mode**, this function must still configure PendSV (or equivalent).
-- Must enable global interrupts before returning.
+### `void hrt__pend_context_switch(void)`
 
----
+Requests a context switch at the port's next safe scheduling point.
 
-### 2.3 Yield / Preemption
+- Cortex-M sets `PENDSVSET`.
+- POSIX sets a `sig_atomic_t` pending flag.
 
-#### `void hrt_port_yield(void);`
+The current core calls this function from task paths and tick/ISR-style paths. It must be safe to call repeatedly.
 
-- **Called by**: Scheduler and APIs like `hrt_sleep()`
-- **Context**: Thread
-- **ISR-safe**: No
-- **Purpose**:
-  - Request a context switch
+### `void hrt_port_idle_wait(void)`
 
-This must **not** perform the context switch directly.
-It must defer to the port’s preemption mechanism.
+Called when no application task is selected.
 
----
+- Cortex-M executes `WFI`.
+- POSIX performs a short `nanosleep()` to avoid a busy loop.
 
-#### `void hrt_port_pend_sv(void);`
+### `void hrt_port_prepare_task_stack(int id, void (*tramp)(void), uint32_t *stack_base, size_t words)`
 
-- **Called by**: Core scheduler
-- **Context**: Thread or ISR
-- **ISR-safe**: Yes
-- **Purpose**:
-  - Mark that a context switch is pending
+Builds or records the initial execution context for a task.
 
-Examples:
-- Cortex-M: set `SCB->ICSR.PENDSVSET`
-- POSIX: set a signal flag
+The current Cortex-M port creates an exception-return frame and saves the resulting stack pointer in the task control block. The POSIX port initializes a `ucontext_t` using the application-provided stack buffer.
 
-Must be safe to call multiple times.
+The stack must remain valid for the task lifetime. `hrt_create_task()` currently rejects stacks smaller than 64 words before this hook is called.
 
----
+### `void hrt__task_trampoline(void)`
 
-## 3. Tick Handling
+Starts the current task's entry function with its stored argument. If the task returns, both current reference ports call `hrt_task_delete()`. Returning tasks are therefore marked unused and are not requeued.
 
-### 3.1 Internal Tick
+### `void hrt_port_crit_enter(void)` / `void hrt_port_crit_exit(void)`
 
-If the port owns the tick source:
+Protect scheduler and synchronization data.
 
-- The tick ISR must call:
-  ```c
-  hrt__tick_isr();
-  ```
+The current core uses these hooks from ordinary task APIs and from the semaphore/queue `_from_isr` paths. A compatible port must therefore support the contexts in which its ISR-facing APIs are permitted.
 
-- The ISR **must not schedule directly**
-- The ISR may request a context switch via `hrt_port_pend_sv()`
+Requirements of the current implementation:
 
----
+- nesting must work;
+- the outermost exit restores or releases the protection;
+- scheduler data must not be observed partially updated;
+- the implementation must not mask faults that are required for platform safety.
 
-### 3.2 External Tick
+The Cortex-M port uses `BASEPRI`. Its defaults are:
 
-If using an external tick source:
+```c
+HARDRT_NVIC_PRIO_BITS       = 4
+HARDRT_MAX_SYSCALL_IRQ_PRIO = 5
+```
 
-- The ISR must call:
-  ```c
-  hrt_tick_from_isr();
-  ```
+An interrupt that calls HardRT ISR APIs must be configured at a priority compatible with that `BASEPRI` ceiling. Numerically lower Cortex-M priority values are more urgent and may not be masked by the critical section.
 
-- The port must ensure:
-  - Correct interrupt priority
-  - No reentrancy into the scheduler
+The POSIX port blocks `SIGALRM` and uses a nesting counter.
 
----
+### `void hrt_port_sp_valid(uintptr_t sp)`
 
-## 4. Critical Sections
+Performs port-specific stack-pointer validation. The Cortex-M implementation checks RAM range and 8-byte alignment. The POSIX implementation currently accepts the supplied value.
 
-#### `void hrt_port_crit_enter(void);`
-#### `void hrt_port_crit_exit(void);`
+### `void hrt__init_idle_task(void)`
 
-- **Called by**: Core scheduler
-- **Context**: Thread
-- **ISR-safe**: No
+Initializes the port's idle representation.
 
-Requirements:
-- Must be nestable
-- Must block preemption
-- Must not mask faults
+The Cortex-M port constructs the idle task context. The POSIX port currently leaves this hook empty and handles idle waiting in the scheduler loop.
 
-Typical implementations:
-- Cortex-M: BASEPRI
-- POSIX: signal masking
+## Core-private functions used by ports
 
----
+The current private port header and source files use functions including:
 
-## 5. Context Switching
+```c
+uint32_t          hrt__cfg_core_hz(void);
+hrt_tick_source_t hrt__cfg_tick_src(void);
+uint32_t          hrt__cfg_tick_hz(void);
+int               hrt__get_current(void);
+int               hrt__pick_next_ready(void);
+void              hrt__save_current_sp(uintptr_t sp);
+uintptr_t         hrt__load_next_sp_and_set_current(int next_id);
+void              hrt__tick_isr(void);
+```
 
-HardRT assumes **cooperative saving** of callee-saved registers.
+Some declarations are still repeated directly in port source files in v0.4.0. A new port must follow the current implementation and `inc/hardrt_port_int.h`; these symbols are not application APIs.
 
-### Requirements
+## Tick handling
 
-- Save and restore:
-  - r4–r11 (or equivalent)
-- Switch stack pointer correctly
-- Resume in thread mode
-- Ensure 8-byte stack alignment
+### Port-owned tick
 
-### First Switch
+When `HRT_TICK_SYSTICK` is selected, the port's timer handler calls:
 
-On first context switch:
-- No task context exists yet
-- Scheduler returns initial task stack pointer
-- Port must transition to task context cleanly
+```c
+hrt__tick_isr();
+```
 
----
+The core handler:
 
-## 6. Task Return Semantics
+- increments the tick counter;
+- wakes expired sleeping tasks;
+- decrements the current task's non-zero timeslice under RR-enabled policies;
+- pends a context switch only when a wake-up or slice expiry requires rescheduling.
 
-If a task function returns:
+### Application-owned external tick
 
-- The task is considered **terminated**
-- It is **not re-queued**
-- No further guarantees are made
+When `HRT_TICK_EXTERNAL` is selected, the application timer ISR calls:
 
-Current behavior:
-- **Cortex-M**: task yields forever
-- **POSIX**: context exits
+```c
+hrt_tick_from_isr();
+```
 
-**Recommendation**: tasks should never return.
+That public function delegates to the same core tick path. If it is called while the configured source is not `HRT_TICK_EXTERNAL`, the current implementation returns without advancing time.
 
----
+The caller does not need to invoke a second yield function. Tick processing requests rescheduling internally when required.
 
-## 7. POSIX Port Notes
+## Context switching
 
-The POSIX reference port:
+### Cortex-M
 
-- Uses `ucontext` (glibc/Linux only)
-- Uses `SIGALRM` as tick source
-- Masks the tick signal during scheduling
-- Uses `sig_atomic_t` for ISR-to-thread flags
+The current Cortex-M port:
 
-Limitations:
-- Not portable to musl or macOS
-- Intended for simulation and CI only
+- uses PSP for task stacks;
+- saves/restores `r4-r11` in PendSV assembly;
+- relies on the hardware exception frame for the remaining basic registers;
+- requires 8-byte stack alignment;
+- sets PendSV below SysTick in interrupt priority.
 
----
+The current implementation does not document or implement floating-point context preservation as part of the task-switch contract.
 
-## 8. Validation Checklist
+### POSIX
 
-Before submitting a new port:
+The POSIX port uses `ucontext` on Linux/glibc and `SIGALRM` for tick accounting.
 
-- [ ] Preemption works under load
-- [ ] Tick ISR never schedules directly
-- [ ] Nested critical sections work
-- [ ] Tasks resume correctly after yield
-- [ ] No stack corruption under stress
-- [ ] All hooks documented
+The signal handler calls `hrt__tick_isr()` and sets a pending flag. It does not call `swapcontext()`. A task reaches the scheduler only through a HardRT scheduling point such as:
 
----
+- `hrt_yield()`;
+- `hrt_sleep()`;
+- blocking semaphore, mutex, or queue operations;
+- `hrt_task_delete()`;
+- returning from the task function.
 
-## 9. Reference Ports
+For that reason, the current POSIX port provides cooperative context handoff even though tick accounting and slice expiration are signal-driven. A CPU-bound task without HardRT scheduling points can prevent other tasks from running.
 
-Use these as templates:
+`ucontext` is treated as a Linux/glibc dependency. The port is not claimed to support musl or macOS.
 
-- `port/posix/`
-- `port/cortex_m/`
+## Validation checklist
 
-If the port deviates, document why.
+Before adding a port, verify at least:
 
----
+- [ ] internal and external tick modes advance time exactly once per tick;
+- [ ] no task context switch is performed directly by a hardware tick handler;
+- [ ] task-context yield reaches the scheduler safely;
+- [ ] nested critical sections preserve state;
+- [ ] every ISR-facing synchronization API is called only from supported interrupt priorities;
+- [ ] initial task stacks satisfy ABI alignment and frame requirements;
+- [ ] task return calls `hrt_task_delete()`;
+- [ ] the idle path does not consume an application ready-queue entry;
+- [ ] stack and scheduler state remain valid under repeated wake, yield, block, and delete operations.
 
-**HardRT Porting Rule:**  
-If it works only when interrupts are slow, it is broken.
+## Reference ports
+
+- `src/port/posix/`
+- `src/port/cortex_m/`
+- `src/port/null/`

--- a/docs/QUEUES.md
+++ b/docs/QUEUES.md
@@ -62,7 +62,9 @@ int hrt_queue_try_recv(hrt_queue_t *queue, void *out);
 
 Both functions return `0` on success and `-1` when the operation cannot be completed immediately.
 
-A successful task-context operation wakes one opposite-side waiter when present. The current implementation then calls `hrt_yield()`, even if the awakened task is not higher priority.
+A successful non-blocking task operation wakes one opposite-side waiter when present and then calls `hrt_yield()`, regardless of relative task priority.
+
+The blocking send/receive loops first call those non-blocking functions. If a blocking operation later succeeds through its protected recheck path, it may wake one opposite-side waiter and return without an additional explicit yield.
 
 ## ISR-context operations
 

--- a/docs/QUEUES.md
+++ b/docs/QUEUES.md
@@ -1,139 +1,156 @@
 # HardRT Message Queues
 
-HardRT provides a fixed-size message queue implementation for inter-task communication. These queues are based on a ring buffer and support both blocking and non-blocking operations, as well as use within Interrupt Service Routines (ISRs).
+HardRT v0.4.0 provides fixed-capacity, copy-based FIFO queues for communication between tasks. Queue storage is supplied by the application; the kernel performs no dynamic allocation.
 
-## Overview
+## Properties
 
-A `hrt_queue_t` object manages a buffer of items of a fixed size.
-- **Copy-based**: Items are copied into and out of the queue buffer using `memcpy`.
-- **FIFO**: Items are delivered in the same order they were sent.
-- **Blocking**: Tasks can block indefinitely when sending to a full queue or receiving from an empty one.
-- **FIFO Waiters**: If multiple tasks are blocked on a queue, they are woken in the order they began waiting.
+- Items have one fixed size selected at initialization.
+- Items are copied with `memcpy`.
+- Queue order is FIFO.
+- Blocking task operations may wait indefinitely.
+- Non-blocking task and ISR operations return immediately.
+- Sender and receiver waiters are stored in separate FIFO task-ID queues.
 
 ## Initialization
-
-Queues use application-provided storage for their internal buffer.
 
 ```c
 #include "hardrt_queue.h"
 
 #define QUEUE_CAPACITY 10
-#define ITEM_SIZE sizeof(my_msg_t)
 
-hrt_queue_t my_queue;
-uint8_t queue_storage[QUEUE_CAPACITY * ITEM_SIZE];
+typedef struct {
+    uint32_t id;
+    uint32_t value;
+} message_t;
 
-void init(void) {
-    hrt_queue_init(&my_queue, queue_storage, QUEUE_CAPACITY, ITEM_SIZE);
+static hrt_queue_t queue;
+static uint8_t queue_storage[QUEUE_CAPACITY * sizeof(message_t)];
+
+static void init_queue(void) {
+    hrt_queue_init(
+        &queue,
+        queue_storage,
+        QUEUE_CAPACITY,
+        sizeof(message_t));
 }
 ```
 
-## Operations
+The storage must remain valid for the queue lifetime and must contain at least `capacity * item_size` bytes.
 
-### Task Context (Blocking)
+## Task-context operations
 
-- `hrt_queue_send`: Sends an item. Blocks if the queue is full.
-- `hrt_queue_recv`: Receives an item. Blocks if the queue is empty.
+### Blocking
 
 ```c
-my_msg_t msg = { .id = 1 };
-hrt_queue_send(&my_queue, &msg); // Blocks until space available
-
-my_msg_t received;
-hrt_queue_recv(&my_queue, &received); // Blocks until item available
+int hrt_queue_send(hrt_queue_t *queue, const void *item);
+int hrt_queue_recv(hrt_queue_t *queue, void *out);
 ```
 
-### Task Context (Non-blocking)
+- `hrt_queue_send()` retries until space is available.
+- `hrt_queue_recv()` retries until an item is available.
+- A full sender joins the TX waiter FIFO and becomes `HRT_BLOCKED`.
+- An empty receiver joins the RX waiter FIFO and becomes `HRT_BLOCKED`.
 
-- `hrt_queue_try_send`: Attempts to send. Returns `0` on success, `-1` if full.
-- `hrt_queue_try_recv`: Attempts to receive. Returns `0` on success, `-1` if empty.
+There are no timeout variants in v0.4.0.
 
-### ISR Context
+### Non-blocking
 
-Queues support sending and receiving from ISRs using specialized functions. These functions never block and provide a `need_switch` flag to indicate if a higher-priority task was woken.
+```c
+int hrt_queue_try_send(hrt_queue_t *queue, const void *item);
+int hrt_queue_try_recv(hrt_queue_t *queue, void *out);
+```
 
-- `hrt_queue_try_send_from_isr`
-- `hrt_queue_try_recv_from_isr`
+Both functions return `0` on success and `-1` when the operation cannot be completed immediately.
+
+A successful task-context operation wakes one opposite-side waiter when present. The current implementation then calls `hrt_yield()`, even if the awakened task is not higher priority.
+
+## ISR-context operations
+
+```c
+int hrt_queue_try_send_from_isr(
+    hrt_queue_t *queue,
+    const void *item,
+    int *need_switch);
+
+int hrt_queue_try_recv_from_isr(
+    hrt_queue_t *queue,
+    void *out,
+    int *need_switch);
+```
+
+These operations never block.
+
+In v0.4.0:
+
+- `*need_switch` is set to `1` whenever the operation wakes any waiter;
+- it is not a comparison between the waiter's priority and the interrupted task's priority;
+- the queue function itself calls `hrt__pend_context_switch()` when a waiter is awakened;
+- the ISR does not call a separate `hrt_port_yield_from_isr()` function, because no such public API exists.
+
+Example:
 
 ```c
 void MY_IRQ_Handler(void) {
-    my_msg_t msg = { .id = 99 };
-    int need_switch = 0;
-    if (hrt_queue_try_send_from_isr(&my_queue, &msg, &need_switch) == 0) {
-        if (need_switch) {
-            hrt_port_yield_from_isr(); // Port-specific yield
-        }
-    }
-}
-```
-
-### Handling Large Data
-
-When transmitting large payloads, avoid enqueuing the data directly. Instead, enqueue a structure containing a pointer to the data and its length. This minimizes `memcpy` overhead and critical section time.
-
-```c
-typedef struct {
-    void    *p_data;
-    size_t   length;
-} my_large_msg_t;
-
-/* Send a pointer to a large buffer */
-void producer(void) {
-    static char big_buffer[1024];
-    my_large_msg_t msg = {
-        .p_data = big_buffer,
-        .length = sizeof(big_buffer)
+    const message_t message = {
+        .id = 99,
+        .value = 1234
     };
-    
-    /* Enqueue the small struct containing the pointer */
-    hrt_queue_send(&my_queue, &msg);
-}
+    int need_switch = 0;
 
-void consumer(void) {
-    my_large_msg_t msg;
-    
-    /* Dequeue the small struct */
-    hrt_queue_recv(&my_queue, &msg);
-    
-    /* Process data via pointer */
-    printf("Received %zu bytes at %p\n", msg.length, msg.p_data);
+    (void)hrt_queue_try_send_from_isr(
+        &queue,
+        &message,
+        &need_switch);
+
+    /* The queue operation has already requested rescheduling when needed.
+       The flag is available for ISR/application bookkeeping. */
+    (void)need_switch;
 }
 ```
 
-## Implementation Details
+The selected port's ISR critical-section rules still apply. On Cortex-M, only interrupts compatible with the configured `BASEPRI` syscall ceiling may call HardRT ISR APIs.
 
-### Data Structure
+## Wake behavior
+
+A successful enqueue wakes at most one receiver. A successful dequeue wakes at most one sender. Waiters are removed FIFO and passed to the common ready-queue insertion path.
+
+The queue does not directly transfer an item between waiting tasks. The awakened task resumes and retries its operation.
+
+## Copy and critical-section cost
+
+The implementation copies the complete item while holding the port critical section:
+
+```c
+memcpy(destination, source, queue->item_size);
+```
+
+Large items therefore increase interrupt-masked or signal-masked time. Prefer small values, indices, or pointers for large payloads.
+
+When queueing pointers, HardRT copies only the pointer value. It does not manage ownership or lifetime of the pointed-to storage.
 
 ```c
 typedef struct {
-    uint8_t *buf;
-    size_t   item_size;
-    uint16_t capacity;
-
-    volatile uint16_t head;
-    volatile uint16_t tail;
-    volatile uint16_t count;
-
-    /* Internal waiter FIFOs for TX and RX */
-    uint8_t rx_q[HARDRT_MAX_TASKS];
-    uint8_t rx_head, rx_tail, rx_wait;
-
-    uint8_t tx_q[HARDRT_MAX_TASKS];
-    uint8_t tx_head, tx_tail, tx_wait;
-} hrt_queue_t;
+    void *data;
+    size_t length;
+} buffer_ref_t;
 ```
 
-### Performance Considerations
+The producer and consumer must define who owns the buffer and when it may be reused.
 
-Because HardRT queues copy data, they are best suited for:
-1. Small data structures (integers, small structs).
-2. Pointers to larger buffers (e.g., from a memory pool).
-3. Indices into an array.
+## Current structure
 
-Large `item_size` will increase the time spent in critical sections during `memcpy`.
+The public `hrt_queue_t` contains:
+
+- storage pointer, item size, capacity, head, tail, and item count;
+- one RX waiter FIFO;
+- one TX waiter FIFO.
+
+Waiter arrays are sized by `HARDRT_MAX_TASKS`. In a CMake build, that macro currently includes the additional idle slot, although the idle task should never wait on a queue.
 
 ## Constraints
 
-- **No Timeouts**: Blocking operations currently block forever.
-- **Fixed Size**: Queue capacity and item size are fixed at initialization.
-- **Memory**: Storage must be provided by the caller and must be large enough (`capacity * item_size`).
+- Capacity and item size cannot change after initialization.
+- Blocking operations have no timeout.
+- No dynamic allocation is performed.
+- Queue state and item storage must outlive all users.
+- ISR operations are non-blocking only; they still execute the configured critical-section mechanism and item copy.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,26 +1,40 @@
-# 📘 Documentation Summary
+# Documentation Summary
 
-This documentation set is synchronized with HardRT v0.4.0.
+This documentation set describes the HardRT v0.4.0 implementation currently present on the `develop` branch.
 
-## Main Docs
-| File                                        | Purpose                                         |
-|---------------------------------------------|-------------------------------------------------|
-| Main [README.md](../README.md)              | Project overview, build instructions, diagrams  |
-| [INTRODUCTION.md](INTRODUCTION.md)          | Background: What is an RTOS? Why HardRT?        |
-| [BUILD.md](BUILD.md)                        | Build and install guide                         |
-| [API_C.md](API_C.md)                        | Public C API reference                          |
-| [CPP.md](CPP.md)                            | C++ header-only wrapper reference               |
-| [PORTING.md](PORTING.md)                    | Porting guide for POSIX and Cortex‑M            |
-| [SEMAPHORES.md](SEMAPHORES.md)              | Semaphore design and API (binary + counting)    |
-| [MUTEXES.md](MUTEXES.md)                    | Mutex design and API                            |
-| [QUEUES.md](QUEUES.md)                      | Queue design and API                            |
-| [EXAMPLES_C.md](EXAMPLES_C.md)              | C and C++ example overview                      |
-| [MODULE_STATUS.md](MODULE_STATUS.md)        | Current module status matrix                    |
-| [TESTS_POSIX.md](TESTS_POSIX.md)            | POSIX test harness notes                        |
-| [STATISTICS.md](STATISTICS.md)              | Statistics on STM32H755ZI-Q                     |
-| [ROADMAP.md](ROADMAP.md)                    | Release roadmap to v1.0.0                       |
-| [DOCUMENTATION.md](DOCUMENTATION.md)        | Doxygen and header documentation guidance       |
+The roadmap and GitHub issues may describe later work. A planned API or behavior is not part of the current public contract until its implementation and tests are merged and the corresponding user documentation is updated.
 
-## Notes
-- The mutex API is now part of the public documented surface.
-- Counting semaphores, mutexes, and queues are implemented in the current codebase.
+## Main documents
+
+| File | Purpose |
+|---|---|
+| [Main README](../README.md) | Project overview and current behavior |
+| [INTRODUCTION.md](INTRODUCTION.md) | Scope and design goals |
+| [BUILD.md](BUILD.md) | Current CMake prerequisites, options, build, and install behavior |
+| [API_C.md](API_C.md) | Current C API behavior |
+| [CPP.md](CPP.md) | Existing C++17 wrapper types and methods |
+| [PORTING.md](PORTING.md) | Hooks and execution model used by the current ports |
+| [TICK_SOURCE.md](TICK_SOURCE.md) | Internal versus external tick ownership |
+| [SEMAPHORES.md](SEMAPHORES.md) | Binary and counting semaphore behavior |
+| [MUTEXES.md](MUTEXES.md) | Mutex behavior and limitations |
+| [QUEUES.md](QUEUES.md) | Queue behavior, storage, and ISR operations |
+| [EXAMPLES_C.md](EXAMPLES_C.md) | Bundled example overview |
+| [MODULE_STATUS.md](MODULE_STATUS.md) | Current source-module status |
+| [TESTS_POSIX.md](TESTS_POSIX.md) | POSIX test-harness behavior and limits |
+| [STATISTICS.md](STATISTICS.md) | Recorded STM32H755 timing measurements and their scope |
+| [ROADMAP.md](ROADMAP.md) | Non-binding work planned toward 1.0.0 |
+| [DOCUMENTATION.md](DOCUMENTATION.md) | Doxygen and documentation guidance |
+
+## Current implemented synchronization surface
+
+- binary and counting semaphores;
+- owner-tracked non-recursive mutexes;
+- fixed-size copy-based message queues.
+
+The current release does not expose event flags, task notifications, IPC timeouts, or mutex priority inheritance.
+
+## Accuracy rule
+
+Where documentation and implementation differ, the source and tests describe what the current binary does. Such differences should be corrected in documentation immediately and tracked as implementation issues only when a different behavior has been deliberately selected for a later release.
+
+The documentation does not claim complete automated synchronization with the source. Compile and link checks for documentation examples are tracked separately.

--- a/docs/SEMAPHORES.md
+++ b/docs/SEMAPHORES.md
@@ -1,98 +1,116 @@
-## 🔒 Semaphores (binary + counting)
+# Semaphores
 
-HardRT provides a small, predictable semaphore primitive for task synchronization and resource management.
+HardRT v0.4.0 provides binary and counting semaphores with application-owned static storage and FIFO waiter ordering.
 
-There are two modes:
+## Modes
 
-- **Binary semaphore:** `max_count = 1`, tokens are `0/1`. Extra `give()` calls saturate at `1`.
-- **Counting semaphore:** `max_count > 1`, tokens range `0..max_count`. Extra `give()` calls saturate at `max_count`.
+- **Binary:** `max_count == 1`, with token count `0` or `1`.
+- **Counting:** `max_count > 1`, with token count from `0` through `max_count`.
 
-Semaphores are deliberately deterministic:
+Extra give operations saturate at the configured maximum.
 
-- **FIFO waiter queue:** tasks that block in `hrt_sem_take()` are queued FIFO.
-- **Direct handoff on wake:** when a `give()` finds a waiter, it wakes exactly one task. The token is handed off to that task rather than accumulated separately.
-- **ISR-safe give:** `hrt_sem_give_from_isr()` can be called from ISR/tick context and reports whether a context switch is needed.
-
----
-
-## API
-
-### Initialization
+## Initialization
 
 ```c
-void hrt_sem_init(hrt_sem_t *s, unsigned init);
-void hrt_sem_init_counting(hrt_sem_t *s, unsigned init, uint8_t max_count);
+void hrt_sem_init(hrt_sem_t *sem, unsigned init);
+void hrt_sem_init_counting(
+    hrt_sem_t *sem,
+    unsigned init,
+    uint8_t max_count);
 ```
 
-- `hrt_sem_init()` creates a binary semaphore. `init` is treated as `0/1`.
-- `hrt_sem_init_counting()` creates a counting semaphore:
-  - `max_count` is clamped to at least `1`.
-  - `init` is clamped to `max_count`.
+Current behavior:
 
-### Take / Try / Give
+- `hrt_sem_init()` creates a binary semaphore and clamps `init` to `0` or `1`.
+- `hrt_sem_init_counting()` changes `max_count == 0` to `1`.
+- An initial value above `max_count` is clamped to `max_count`.
+- Initialization clears the waiter FIFO.
+
+## Operations
 
 ```c
-int hrt_sem_take(hrt_sem_t *s);
-int hrt_sem_try_take(hrt_sem_t *s);
-int hrt_sem_give(hrt_sem_t *s);
-int hrt_sem_give_from_isr(hrt_sem_t *s, int *need_switch);
+int hrt_sem_take(hrt_sem_t *sem);
+int hrt_sem_try_take(hrt_sem_t *sem);
+int hrt_sem_give(hrt_sem_t *sem);
+int hrt_sem_give_from_isr(hrt_sem_t *sem, int *need_switch);
 ```
 
-Behavior:
-- `try_take()` succeeds only if at least one token is available.
-- `take()` blocks if no token is available.
-- `give()`:
-  - If there is a waiter: wakes exactly one waiter by direct handoff.
-  - If there is no waiter: increments the token count, saturating at `max_count`.
-- `give_from_isr()` behaves like `give()` but sets `*need_switch = 1` if the wake should trigger rescheduling after the ISR.
+### Try take
 
----
+`hrt_sem_try_take()` decrements and succeeds when a token is available. It returns `-1` without blocking when the count is zero.
 
-## Use semaphores for the right thing
+### Blocking take
 
-Semaphores are appropriate for:
-- event signaling
-- producer/consumer wakeups
-- counting available resources
+`hrt_sem_take()` first tries the fast path. When no token is available, it:
 
----
+1. enters the port critical section;
+2. checks the count again;
+3. appends the current task ID to the FIFO waiter queue;
+4. marks the task `HRT_BLOCKED`;
+5. requests rescheduling and transfers to the scheduler.
 
-## Examples
+There is no timeout variant in v0.4.0.
 
-### Binary semaphore (event gate)
+### Task-context give
+
+When a waiter exists, `hrt_sem_give()` removes exactly one FIFO waiter and passes it to the ready-queue insertion path. The token is handed directly to that waiter rather than incrementing the stored count.
+
+The current implementation then calls `hrt_yield()` whenever a waiter was awakened. It does this regardless of the relative priorities of the giver and waiter.
+
+When no waiter exists, the stored count is incremented up to `max_count`.
+
+### ISR give
+
+`hrt_sem_give_from_isr()` performs the same direct handoff without blocking.
+
+In v0.4.0:
+
+- `*need_switch` is set to `1` whenever any waiter was awakened;
+- the value does not specifically mean that a higher-priority task was awakened;
+- the function calls `hrt__pend_context_switch()` itself when a waiter is awakened;
+- the ISR does not call an additional yield function.
+
+The selected port's ISR critical-section rules apply. Cortex-M callers must use an interrupt priority compatible with the configured `BASEPRI` syscall ceiling.
+
+## Binary semaphore example
 
 ```c
-static hrt_sem_t sem;
+static hrt_sem_t ready;
 
-void init(void) {
-    hrt_sem_init(&sem, 0);
+static void init_sync(void) {
+    hrt_sem_init(&ready, 0);
 }
 
-void producer(void*) {
+static void producer(void *arg) {
+    (void)arg;
     for (;;) {
-        hrt_sem_give(&sem);
+        hrt_sem_give(&ready);
         hrt_sleep(100);
     }
 }
 
-void consumer(void*) {
+static void consumer(void *arg) {
+    (void)arg;
     for (;;) {
-        hrt_sem_take(&sem);
-        /* handle event */
+        hrt_sem_take(&ready);
+        /* Handle one synchronization event. */
     }
 }
 ```
 
-### Counting semaphore (resource pool)
+A binary semaphore stores at most one pending token. Multiple gives performed while no task is waiting collapse into the single available state.
+
+## Counting semaphore example
 
 ```c
 static hrt_sem_t slots;
 
-void init(void) {
+static void init_slots(void) {
     hrt_sem_init_counting(&slots, 0, 5);
 }
 
-void producer(void*) {
+static void producer(void *arg) {
+    (void)arg;
     for (;;) {
         hrt_sem_give(&slots);
         hrt_sem_give(&slots);
@@ -100,7 +118,8 @@ void producer(void*) {
     }
 }
 
-void consumer(void*) {
+static void consumer(void *arg) {
+    (void)arg;
     for (;;) {
         hrt_sem_take(&slots);
         hrt_sleep(200);
@@ -108,10 +127,23 @@ void consumer(void*) {
 }
 ```
 
----
+## Appropriate uses
 
-## Notes and guarantees
+Semaphores are suitable for:
 
-- Saturation is intentional.
-- For never-lose-data semantics, a semaphore alone is not a queue. Use a queue or ring buffer for the payload, optionally with a semaphore as the wakeup signal.
-- No timeout variants are present yet in the current public API.
+- task wake-up signaling;
+- producer/consumer coordination;
+- counting a fixed number of available resources.
+
+Semaphores are not owner-tracked and should not be used where only the acquiring task may release a protected resource. Use `hrt_mutex_t` for that contract.
+
+A semaphore does not carry payload data. When every produced item must be retained, use a queue or application ring buffer rather than relying only on a binary signal.
+
+## Current constraints
+
+- FIFO waiter ordering.
+- No timeout operations.
+- No cancellation API for a blocked waiter.
+- No priority ordering of waiter queues.
+- No dynamic allocation.
+- `need_switch` reports that a waiter was awakened, not a completed priority comparison.

--- a/docs/STATISTICS.md
+++ b/docs/STATISTICS.md
@@ -1,126 +1,122 @@
-# HardRT – Timing & Latency Characterization
+# HardRT Timing and Latency Measurements
 
-This document contains performance data collected for **HardRT v0.4.0** on STM32H7.
-The measurements demonstrate deterministic behavior and the impact of task priorities on scheduling latency.
+This document records measurements collected for HardRT v0.4.0 on one STM32H755 Cortex-M7 setup. The results characterize that setup and workload. They are not a proof of a universal worst-case execution-time or end-to-end latency bound.
 
-All measurements were performed **without modifying HardRT core logic**, using application-level instrumentation and the Cortex-M DWT cycle counter.
+## Recorded setup
 
----
+### Target
 
-## Test Setup
-
-**Target**
-- MCU: STM32H755 (Cortex-M7)
+- MCU: STM32H755, Cortex-M7 core
 - Core clock: 64 MHz (`SystemCoreClock = 64_000_000`)
-- Port: `cortex_m`
+- HardRT port: `cortex_m`
 
-**Build**
+### Build
+
 - Configuration: Release
-- Semihosting: Disabled
-- Debug variables: Disabled
+- Semihosting: disabled
+- HardRT debug variables: disabled
 
-**Measurement method**
-- ISR timestamps event using `DWT->CYCCNT`
-- ISR signals a semaphore (`hrt_sem_give_from_isr`)
-- High-priority task timestamps on semaphore take
-- Latency = `t_task_entry - t_event`
-- Samples per test: 10,000
+The original record does not pin every compiler, linker, cache, flash-wait-state, FPU, interrupt-load, and memory-placement detail needed to reproduce a formal upper bound. Treat the values below as historical measurements until that information and the raw artifacts are captured together.
 
-**Tick mode**
-- External tick (kernel time advanced externally)
-- Measurements focus on **event → task execution**, not timekeeping accuracy
+### Measurement method
 
----
+- An ISR timestamps an event using `DWT->CYCCNT`.
+- The ISR calls `hrt_sem_give_from_isr()`.
+- The awakened task timestamps after its semaphore take returns.
+- Reported latency is the unsigned cycle difference between those timestamps.
+- Each recorded case contains 10,000 samples.
 
-## Representative Run (Tick PRIO0, Event PRIO0)
+### Tick mode
 
-This run shows the full console output for the **equal-priority** case (both tick and event tasks at **PRIO0**).
+The measurements used external tick mode. They focus on ISR signal to task execution rather than accuracy of the kernel time base.
 
-Command used:
+## Representative recorded run
+
+The following command shape was used with the repository timing example and GDB script:
+
+```bash
+gdb-multiarch \
+  -q examples/hardrt_h755_dwt_timing/build-cortex_m/hardrt_cm7_dwt_timing.elf \
+  -batch \
+  -x scripts/gdb/timing.dbg
 ```
-dev in dev in hardrt on  develop [!?⇡] via △ v3.22.1 took 25s 
-➜ gdb-multiarch -q examples/hardrt_h755_dwt_timing/build-cortex_m/hardrt_cm7_dwt_timing.elf -batch -x scripts/gdb/timing.dbg
-```
 
-Console output:
-```
-0x080006cc in Reset_Handler ()
-semihosting is disabled
+The build directory is illustrative. Reproduction requires generating the firmware for the same target and configuration first.
 
-target halted due to debug-request, current mode: Thread 
-xPSR: 0x01000000 pc: 0x080006cc msp: 0x20020000
-Breakpoint 1 at 0x8000d68
-Note: automatically using hardware breakpoints for read-only addresses.
-Breakpoint 2 at 0x80007c6
+Recorded output for the equal-priority case:
 
---- Target reached ---
+```text
 SystemCoreClock=64000000 Hz
 
 [TICK -> TASK]
 count=10000
-min=1161 cycles, avg=1414 cycles (sum/count=1414), max=2232 cycles
+min=1161 cycles, avg=1414 cycles, max=2232 cycles
 min=18 us, avg=22 us, max=34 us (approx)
-min=18140 ns, avg=22093 ns, max=34875 ns
 
 [SEM GIVE -> TASK TAKE]
 count=10000
-min=1201 cycles, avg=1547 cycles (sum/count=1547), max=2893 cycles
+min=1201 cycles, avg=1547 cycles, max=2893 cycles
 min=18 us, avg=24 us, max=45 us (approx)
-min=18765 ns, avg=24171 ns, max=45203 ns
 
 [TIMER CFG]
 TIM2: PSC=31 ARR=999 us period
 TIM3: PSC=31 ARR=4999 us period
-[Inferior 1 (Remote target) detached]
 ```
 
----
+## Recorded priority-interaction results
 
-## Priority Interaction Results
+Two tasks were used:
 
-Two latency-sensitive tasks were used:
-- **Tick task** (periodic event)
-- **Event task** (asynchronous external event)
+- a periodic tick-related task;
+- an asynchronous event task.
 
-Both tasks are woken via ISR-signaled semaphores.
+Both were awakened through ISR semaphore gives.
 
-### Summary Table
+| Test | Task priorities | Metric | Min cycles | Avg cycles | Max cycles | Min µs | Avg µs | Max µs |
+|---:|---|---|---:|---:|---:|---:|---:|---:|
+| 0 | Tick PRIO0, Event PRIO0 | Tick to task | 1161 | 1414 | 2232 | 18 | 22 | 34 |
+| 0 | Tick PRIO0, Event PRIO0 | Event to task | 1201 | 1547 | 2893 | 18 | 24 | 45 |
+| 1 | Tick PRIO0, Event PRIO1 | Tick to task | 1161 | 1348 | 1879 | 18 | 21 | 29 |
+| 1 | Tick PRIO0, Event PRIO1 | Event to task | 1301 | 1636 | 2957 | 20 | 25 | 46 |
+| 2 | Tick PRIO1, Event PRIO0 | Tick to task | 1261 | 1741 | 3559 | 19 | 27 | 55 |
+| 2 | Tick PRIO1, Event PRIO0 | Event to task | 1158 | 1221 | 1242 | 18 | 19 | 19 |
 
-| Test | Task Priorities                 | Metric       | Min (cycles) | Avg (cycles) | Max (cycles) | Min (µs) | Avg (µs) | Max (µs) |
-|-----:|---------------------------------|--------------|-------------:|-------------:|-------------:|---------:|---------:|---------:|
-|    0 | Tick **PRIO0**, Event **PRIO0** | Tick → Task  |         1161 |         1414 |         2232 |       18 |       22 |       34 |
-|    0 | Tick **PRIO0**, Event **PRIO0** | Event → Task |         1201 |         1547 |         2893 |       18 |       24 |       45 |
-|    1 | Tick **PRIO0**, Event **PRIO1** | Tick → Task  |         1161 |         1348 |         1879 |       18 |       21 |       29 |
-|    1 | Tick **PRIO0**, Event **PRIO1** | Event → Task |         1301 |         1636 |         2957 |       20 |       25 |       46 |
-|    2 | Tick **PRIO1**, Event **PRIO0** | Tick → Task  |         1261 |         1741 |         3559 |       19 |       27 |       55 |
-|    2 | Tick **PRIO1**, Event **PRIO0** | Event → Task |         1158 |         1221 |         1242 |       18 |       19 |       19 |
+Microsecond values are approximate conversions from the reported 64 MHz cycle counts.
 
----
+## Interpretation limited to this run
 
-## Interpretation
+The recorded traces are consistent with the current priority-ordered ready-queue implementation: when both measured tasks were ready at a scheduling decision, the higher-priority task was selected first.
 
-- When multiple tasks are woken concurrently, **HardRT always schedules the highest-priority READY task first**.
-- With equal priority (PRIO0/PRIO0), both latency paths remain in the same ballpark, but jitter reflects contention and timing alignment.
-- The highest-priority task consistently exhibits **lower average latency and tighter jitter** when priorities differ.
-- Lower-priority tasks absorb interference caused by:
-    - context save/restore of higher-priority tasks
-    - scheduler execution
-    - shared interrupt and memory activity
+The measurements also show that observed latency varied with task priority and contention in this workload. They do not establish that every higher-priority wake has the same latency, or that lower-priority delay is bounded independently of application behavior.
 
-This behavior is **intentional and deterministic**, and matches the expected contract of a priority-based real-time scheduler.
+Factors not represented by the simplified table can include:
 
-**Note on v0.4.0 changes:** 
-Measurements for v0.4.0 show a slight improvement in the best-case latency (min cycles) and more consistent performance across priority levels compared to v0.3.0. The fundamental behavior remains identical: higher priority tasks pre-empt or execute before lower priority tasks when both are ready.
+- time spent in HardRT critical sections;
+- higher-urgency interrupts permitted above the `BASEPRI` ceiling;
+- execution of already-ready higher-priority tasks;
+- queue or semaphore processing;
+- compiler optimization and code placement;
+- cache, flash, bus, and memory effects;
+- debug or trace instrumentation;
+- optional floating-point context requirements.
 
----
+A continuously ready higher-priority task can starve lower-priority work. Any application-level deadline claim therefore requires a workload and interrupt analysis in addition to the kernel measurements.
 
-## Notes on Tick Source
+## Tick-source relevance
 
-These measurements were performed using **external tick mode**.  
-This choice isolates **event → task latency** from kernel timekeeping behavior.
+External tick mode was used to isolate the semaphore event path from SysTick configuration. Changing to the internal SysTick source can change interrupt interaction, tick-handler timing, and wake-up timing. The data here should not be assumed unchanged without measurement.
 
-Using SysTick instead would primarily affect:
-- tick ISR execution time
-- wake-up of sleeping tasks
+## Reproduction status
 
-It does **not** materially change the semaphore-based event → task latency path shown above.
+The repository contains the timing example and GDB script referenced above, but the historical record does not yet contain a complete reproducibility bundle with:
+
+- exact HardRT commit SHA;
+- compiler and binutils versions;
+- complete compile and link flags;
+- board revision and clock configuration;
+- cache, FPU, and flash settings;
+- interrupt priorities and competing interrupt load;
+- raw machine-readable samples;
+- analysis script and expected output.
+
+Until those are recorded together, use this page as a performance observation for the stated setup, not as a certified maximum-latency specification.

--- a/docs/TESTS_POSIX.md
+++ b/docs/TESTS_POSIX.md
@@ -1,99 +1,99 @@
-# POSIX Test Suite — Validating HardRT on Linux
+# POSIX Test Suite
 
-This document explains how the POSIX-hosted test suite validates the HardRT static library, how to build and run it, and what `HARDRT_TEST_HOOKS` means.
+This document describes the hosted test suite for HardRT v0.4.0.
 
-## Overview
-- Target: POSIX port (`HARDRT_PORT=posix`)
-- Artifact: `hardrt_tests` (single executable)
-- Purpose: Deterministically exercise core scheduling/time behavior on a desktop host using a signal-driven tick and cooperative context switching.
-- Output: Numbered test cases with colorized PASS/FAIL lines and a final summary.
+## Purpose and execution model
 
-The suite is self-contained; it does not pull any external test framework.
+- Port: `posix`
+- Test executable: `hardrt_tests`
+- Tick source: normally `SIGALRM`
+- Task contexts: Linux/glibc `ucontext`
+- Context handoff: cooperative at HardRT scheduling points
 
-## What is HARDRT_TEST_HOOKS?
-Some tests need additional visibility or control to be deterministic (e.g., stop the scheduler cleanly, fast-forward ticks, inspect idle activity). To support this, the POSIX port and core expose a few extra symbols guarded by the compile-time macro `HARDRT_TEST_HOOKS`.
+The signal handler advances tick accounting and marks rescheduling pending. It does not call `swapcontext()`. A task returns control to the scheduler through sleep, yield, blocking IPC, deletion, or task return.
 
-- When building tests via CMake on the POSIX port, `HARDRT_TEST_HOOKS` is REQUIRED and is automatically defined for the library target:
-  - `target_compile_definitions(hardrt PRIVATE HARDRT_TEST_HOOKS)`
-- These hooks do not exist in normal (non-test) builds and have no impact on release functionality.
-- In this project’s configuration, POSIX tests are always built with hooks enabled; if they are manually disabled, hook-dependent tests will fail fast rather than silently skipping, because they validate essential scheduler behavior.
+The POSIX suite validates core logic and hosted integration. It is not a timing-accuracy test for Cortex-M.
 
-Examples of test-only hooks (POSIX):
-- `hrt__test_stop_scheduler()` / `hrt__test_reset_scheduler_state()` — deterministic start/stop of the scheduler loop.
-- `hrt__test_fast_forward_ticks(uint32_t delta)` — advance the core tick with `SIGALRM` masked (used for wraparound testing).
-- `hrt__test_idle_counter_reset()` / `hrt__test_idle_counter_value()` — observe idle-loop activity.
-- Core helpers under tests: `hrt__test_set_tick(uint32_t)` / `hrt__test_get_tick()`.
+## Test hooks
 
-## Building and running
+Tests compile the library and test executable with `HARDRT_TEST_HOOKS`.
 
-### With CMake (example)
+Current hooks include:
+
+- `hrt__test_stop_scheduler()`
+- `hrt__test_reset_scheduler_state()`
+- `hrt__test_fast_forward_ticks(uint32_t delta)`
+- `hrt__test_idle_counter_reset()`
+- `hrt__test_idle_counter_value()`
+- `hrt__test_set_tick(uint32_t value)`
+- `hrt__test_get_tick()`
+
+These symbols are not part of a normal release build.
+
+## Build and run
+
+```bash
+cmake -S . -B build-tests \
+  -DHARDRT_PORT=posix \
+  -DHARDRT_BUILD_TESTS=ON
+cmake --build build-tests --target hardrt_tests -j
+ctest --test-dir build-tests --output-on-failure
 ```
-mkdir build && cd build
-cmake -DHARDRT_PORT=posix -DHARDRT_BUILD_TESTS=ON ..
-cmake --build . --target hardrt_tests
-./hardrt_tests
-```
 
-Or via CTest:
-```
-ctest --output-on-failure
-```
+`HARDRT_BUILD_TESTS` defaults to ON, but the executable is created only when `HARDRT_PORT=posix`.
 
-Prerequisites at configured time:
-- `-DHARDRT_PORT=posix`
-- `-DHARDRT_BUILD_TESTS=ON` (default ON)
+The helper script also runs the suite:
 
-If either is missing or the port is not `posix`, the `hardrt_tests` target is skipped.
-
-### Using the helper script
-The helper script also builds and runs the test suite before launching the example:
-```
+```bash
 ./scripts/build-lib-posix.sh
 ```
-It will abort before running the example if any test fails.
 
-## What the suite covers
-Existing groups (non-exhaustive summary):
-- Identity & init basics
-- Sleep/wake determinism and controlled scheduler stop
-- Round-robin fairness with yield and with short sleeps
-- Strict priority dominance (PRIORITY policy)
-- Cooperative vs RR mix within the same priority class
-- Tick-rate independence (e.g., 200 Hz) via correct ms→tick conversion
-- Task creation limits, default attributes behavior
-- Runtime tuning at runtime (policy switch)
-- Ready-queue FIFO order in a priority class
-- Tick wraparound safety (requires `HARDRT_TEST_HOOKS`)
-- `sleep(0)` semantics vs `yield()`
-- Task return stability (task entry returns without crashing the scheduler)
+## Current coverage
 
-All tests are deterministic and bounded; the POSIX scheduler is stopped by a test hook when a case is complete.
+The registered test sources cover:
 
-## Output format
-Each case prints:
-- A heading: `==== Test N/TOTAL: <Name> ====`
-- One or more colorized assertion lines:
-  - `PASS: <description>` (green)
-  - `FAIL: <description>` with diagnostics (red)
-- A per-test result line and an end-of-suite summary:
+- version, port identity, and basic initialization;
+- sleep/wake behavior and controlled scheduler shutdown;
+- same-priority yield and sleep rotation;
+- strict priority dominance;
+- cooperative versus sliced tasks within a priority class;
+- tick-rate conversion;
+- task creation limits and default attributes;
+- runtime policy/default-slice updates;
+- FIFO ready-queue order within a priority class;
+- tick wraparound;
+- current `sleep(0)` behavior;
+- task return;
+- semaphores, queues, mutexes, and external tick mode;
+- idle behavior and `hrt_now_ms()`.
+
+The `sleep(0)` test currently verifies that `hrt_sleep(0)` delays for at least one tick. It does not treat zero as an alias for `hrt_yield()`.
+
+The RR tests exercise tasks within the same priority class. They do not prove that `HRT_SCHED_RR` ignores task priorities; the current scheduler continues to select the highest non-empty priority queue.
+
+## Output
+
+Each test prints a heading, assertion results, and a suite summary. The process returns zero only when all registered cases pass.
+
+## Sanitizer behavior
+
+With `HARDRT_SANITIZE=ON`, the test configuration enables UndefinedBehaviorSanitizer:
+
+```text
+-fsanitize=undefined -fno-omit-frame-pointer
 ```
-================ Summary ================
-Total tests: <N>
-  Passed: <n>
-  Failed: <m>
-========================================
-```
-The test runner returns exit code 0 if all tests passed; non-zero otherwise.
 
-## Skipped tests and hook-dependent behavior
-- Some cases (e.g., tick wraparound) rely on `HARDRT_TEST_HOOKS`. If the library under test was not built with these hooks, such cases are reported as skipped in their group implementation or omitted from registration.
-- In the default POSIX test configuration provided by this project, hooks are enabled, so no cases are skipped.
+AddressSanitizer is not enabled because `makecontext()` and `swapcontext()` are not compatible with the intended ASan setup.
 
-## Validating the library
-For the POSIX port, a successful run of `hardrt_tests` indicates that:
-- The core time base (`hrt_tick_now`) is consistent with the configured tick rate.
-- Sleep/wake and round-robin accounting behave as specified.
-- Priority policy invariants hold (strict priority wins, FIFO within a class).
-- The port integrates correctly with the core: no context switches in the signal handler; rotation at scheduler re-entry with `SIGALRM` masked.
+## What a passing suite demonstrates
 
-This provides a strong signal that the static library (`libhardrt.a`) is functionally correct on the POSIX host port.
+A passing run provides evidence that, on the tested Linux/glibc environment:
+
+- core tick and millisecond conversion behave as asserted by the tests;
+- sleep, wake, block, and ready-queue transitions complete without detected test failures;
+- same-priority FIFO and slice behavior matches the registered cases;
+- synchronization primitives integrate with the hosted scheduler;
+- no context switch is performed directly in the SIGALRM handler;
+- test-only scheduler shutdown remains deterministic.
+
+It does not establish Cortex-M timing bounds, portability to another libc, global priority-independent round-robin semantics, or absence of defects outside the covered cases.

--- a/docs/TICK_SOURCE.md
+++ b/docs/TICK_SOURCE.md
@@ -1,33 +1,74 @@
-# Tick Source (external tick)
+# Tick Sources
 
-HardRT can use either a port‑owned periodic tick or an application‑provided (external) tick.
+HardRT v0.4.0 supports a port-owned periodic tick and an application-owned external tick. Both modes use the same core tick-accounting function, but they enter it through different interfaces.
 
-- `HRT_TICK_SYSTICK` (default): the active port starts its own timer and calls `hrt_tick_from_isr()` every tick.
-- `HRT_TICK_EXTERNAL`: the application owns a hardware timer and must call `hrt_tick_from_isr()` from its timer ISR on every tick.
+## Port-owned tick
 
-How to select it at init:
+`HRT_TICK_SYSTICK` is the default.
+
+The selected port starts its timer from `hrt_port_start_systick()` and calls the private core handler from the timer interrupt or hosted tick callback:
+
+```c
+hrt__tick_isr();
+```
+
+This is the path used by the current Cortex-M SysTick handler and POSIX `SIGALRM` handler.
+
+Application code must not call `hrt_tick_from_isr()` in this mode. The current implementation ignores such a call and does not advance the tick counter.
+
+## Application-owned external tick
+
+Select external mode during initialization:
+
 ```c
 #include "hardrt.h"
 
-int main(void){
-    hrt_config_t cfg = {0};
-    cfg.tick_hz  = 1000;                // system tick frequency (Hz)
-    cfg.tick_src = HRT_TICK_EXTERNAL;   // app provides the tick
+int main(void) {
+    hrt_config_t cfg = {
+        .tick_hz = 1000,
+        .policy = HRT_SCHED_PRIORITY_RR,
+        .default_slice = 5,
+        .core_hz = 0,
+        .tick_src = HRT_TICK_EXTERNAL
+    };
+
     hrt_init(&cfg);
     hrt_start();
 }
 ```
 
-From the timer ISR (external mode):
+The application timer ISR calls the public API once per configured kernel tick:
+
 ```c
 #include "hardrt_time.h"
 
-void MyTimer_IRQHandler(void){
-    // ... clear timer IRQ flag ...
+void MyTimer_IRQHandler(void) {
+    /* Clear the timer interrupt source first. */
     hrt_tick_from_isr();
 }
 ```
 
-Notes
-- `hrt_tick_from_isr()` advances time and wakes sleepers; request a context switch using the port’s mechanism if needed.
-- Some ports may also use `cfg.core_hz` to program their own timer when in `HRT_TICK_SYSTICK` mode.
+In external mode, `hrt_port_start_systick()` must not start its own periodic source. The current Cortex-M port still configures PendSV and enables interrupts; the POSIX port returns without installing `SIGALRM`.
+
+## What tick processing does
+
+Each accepted tick:
+
+1. increments the 32-bit tick counter;
+2. wakes sleeping tasks whose deadlines have expired;
+3. decrements the current task's non-zero slice under `HRT_SCHED_RR` or `HRT_SCHED_PRIORITY_RR`;
+4. requests a context switch when a task was awakened or a slice reached zero.
+
+Tick processing does not switch task contexts directly. Cortex-M performs the eventual transfer through PendSV. POSIX performs it only after a task returns to the scheduler through a HardRT scheduling point.
+
+The timer ISR does not need to call a separate `yield_from_isr` function. No such public API exists in v0.4.0.
+
+## Tick frequency and millisecond conversion
+
+`tick_hz` defines the conversion between milliseconds and ticks. `hrt_sleep()` uses ceiling division, so a positive duration shorter than one tick sleeps for one tick.
+
+In the current implementation, `hrt_sleep(0)` also sleeps for one tick. Use `hrt_yield()` for an immediate voluntary scheduling point.
+
+## Wraparound
+
+The tick counter is a `uint32_t` and wraps naturally. Sleeping-task deadlines are compared using signed subtraction, which supports intervals shorter than half of the 32-bit tick range.

--- a/inc/hardrt.h
+++ b/inc/hardrt.h
@@ -7,8 +7,10 @@ extern "C" {
 #endif
 
 /**
- * @brief Maximum number of concurrent tasks supported by the kernel.
+ * @brief Total number of task-control slots supported by the kernel.
  * @note Can be overridden at compile time via -DHARDRT_MAX_TASKS.
+ *       CMake currently defines this as HARDRT_CFG_MAX_TASKS + 1 so that one
+ *       additional slot is reserved for the idle task.
  */
 #ifndef HARDRT_MAX_TASKS
 #define HARDRT_MAX_TASKS 8
@@ -73,10 +75,14 @@ typedef enum {
 }hrt_err;
 
 /**
- * @brief Scheduler policy.
- * - HRT_SCHED_PRIORITY: strict fixed-priority, cooperative within a class.
- * - HRT_SCHED_RR: single round-robin class.
- * - HRT_SCHED_PRIORITY_RR: fixed-priority with round-robin within each class.
+ * @brief Scheduler policy used by the v0.4.0 implementation.
+ *
+ * Ready tasks are stored in FIFO queues per priority and all policies select
+ * from the highest non-empty priority queue.
+ * - HRT_SCHED_PRIORITY: fixed-priority selection without tick-driven rotation.
+ * - HRT_SCHED_RR: enables time-slice accounting but still respects priorities.
+ * - HRT_SCHED_PRIORITY_RR: fixed-priority selection with time-slice rotation
+ *   inside each priority class.
  */
 typedef enum {
     HRT_SCHED_PRIORITY = 0,
@@ -110,7 +116,8 @@ typedef enum {
 
 /**
  * @brief Kernel initialization parameters.
- * @note All fields are optional; zero initializes to defaults.
+ * @note Zero tick_hz selects 1000 Hz and zero default_slice selects 5 ticks.
+ *       Policy and tick-source values are not validated in v0.4.0.
  */
 typedef struct {
     uint32_t tick_hz; // kernel tick frequency (Hz)
@@ -191,10 +198,12 @@ const char *hrt_port_name(void);
 int hrt_port_id(void);
 
 /**
- * @brief Initialize the kernel and start the system tick on the active port.
+ * @brief Initialize kernel state and invoke the active port tick-start hook.
  * @param cfg Optional configuration; pass NULL for defaults.
- * @return 0 on success; negative on error.
- * @note Must be called before any other API. Safe to call once.
+ * @return The v0.4.0 implementation returns 0.
+ * @note Call once before creating tasks or starting the scheduler. The current
+ *       implementation does not reject repeated initialization or invalid
+ *       lifecycle ordering.
  */
 int hrt_init(const hrt_config_t *cfg);
 
@@ -218,19 +227,21 @@ int hrt_create_task(hrt_task_fn fn, void *arg,
                     const hrt_task_attr_t *attr);
 
 /**
- * @brief Enter the scheduler loop; does not return on preemptive ports.
+ * @brief Enter the scheduler loop; does not return on the Cortex-M port.
  * @note On the null port this returns immediately without running tasks.
  */
 void hrt_start(void);
 
 /**
  * @brief Sleep the calling task for at least the specified milliseconds.
- * @param ms Milliseconds to sleep; 0 yields immediately.
+ * @param ms Milliseconds to sleep. In v0.4.0, zero is rounded up to one tick.
+ * @note Use hrt_yield() for an immediate voluntary scheduling point.
  */
 void hrt_sleep(uint32_t ms);
 
 /**
- * @brief Yield the processor voluntarily to allow other ready tasks to run.
+ * @brief Yield the processor voluntarily, moving the current READY task to the
+ * tail of its priority queue and refreshing its configured slice.
  */
 void hrt_yield(void);
 
@@ -248,21 +259,21 @@ void hrt_task_delete(void);
 uint32_t hrt_tick_now(void);
 
 /**
- * @brief Get the elapsed system time in milliseconds since boot.
- * @return Milliseconds since hrt_init().
+ * @brief Get the elapsed system time in milliseconds since initialization.
+ * @return Milliseconds derived from the current tick and configured tick rate.
  */
 uint32_t hrt_now_ms(void);
 
 /**
- * @brief Change the scheduler policy at runtime.
- * @param p New policy to apply.
- * @note Effect takes place on the next scheduling point.
+ * @brief Change the scheduler policy value at runtime.
+ * @param p New policy value to store.
+ * @note The current implementation performs no validation or ready-queue rebuild.
  */
 void hrt_set_policy(hrt_policy_t p);
 
 /**
- * @brief Change the default round-robin timeslice used when creating tasks.
- * @param t Timeslice in ticks; 0 disables RR for tasks without an explicit slice.
+ * @brief Change the default timeslice used by tasks created later with attr==NULL.
+ * @param t Timeslice in ticks; 0 creates cooperative default tasks.
  */
 void hrt_set_default_timeslice(uint16_t t);
 
@@ -270,7 +281,9 @@ void hrt_set_default_timeslice(uint16_t t);
 /**
  * @brief Start the port-specific system tick source with the given frequency.
  * @param tick_hz Tick frequency in Hz.
- * @note Called by hrt_init(). Port must call hrt_tick_from_isr() at each tick.
+ * @note Called by hrt_init(). In port-owned tick mode, the port handler calls
+ *       the private hrt__tick_isr() core function. In external mode, the port
+ *       must not start its own periodic tick.
  */
 void hrt_port_start_systick(uint32_t tick_hz);
 
@@ -288,7 +301,7 @@ void hrt__pend_context_switch(void); /* request a switch (e.g., PendSV) */
 
 /**
  * @brief Architecture-specific trampoline that enters the task function.
- * @note Provided by the port; sets up a call to the user task entry and handles return.
+ * @note Provided by the port; calls hrt_task_delete() when the task returns.
  */
 void hrt__task_trampoline(void); /* arch-specific entry trampoline */
 

--- a/inc/hardrt_time.h
+++ b/inc/hardrt_time.h
@@ -1,35 +1,31 @@
 #ifndef HARDRT_TIME_H
 #define HARDRT_TIME_H
+
 #include <stdint.h>
+
 #ifdef __cplusplus
 extern "C" {
-
 #endif
 
 /**
- * @brief Advance the kernel tick from a timer ISR.
+ * @brief Advance the kernel tick from an application-owned timer ISR.
  *
- * @details Called once per hardware tick to update time accounting and wake
- * sleeping tasks whose deadlines have expired.
- * - If the port owns the tick (e.g., SysTick), the port's ISR should call this.
- * - If the application owns a hardware timer (HRT_TICK_EXTERNAL), that ISR should call this.
+ * @details This public entry point is used only when the kernel was initialized
+ * with HRT_TICK_EXTERNAL. It advances time accounting, wakes expired sleeping
+ * tasks, updates round-robin slice accounting, and requests rescheduling when
+ * required.
  *
- * This function does not perform a context switch directly; the port or ISR
- * should request one in a port-appropriate way after calling this function.
+ * When the selected tick source is HRT_TICK_SYSTICK, the current implementation
+ * ignores this call. Port-owned tick handlers call the private hrt__tick_isr()
+ * function instead.
+ *
+ * This function never performs a task-context switch directly. A caller does
+ * not need to invoke a second yield-from-ISR function.
  */
 void hrt_tick_from_isr(void);
-
-
-// internal tick isr function.
-/**
- * @brief Kernel tick handler invoked by the port at each system tick.
- * @note Ports must call this from their timer ISR or tick thread context.
- *       The function is safe to call at interrupt context; it accounts time,
- *       wakes sleeping tasks whose deadlines expired, and requests reschedule.
- */
-//void hrt__tick_isr(void);
 
 #ifdef __cplusplus
 }
 #endif
+
 #endif


### PR DESCRIPTION
## Summary

Aligns the user documentation and public API comments with the behavior currently implemented on `develop`.

This PR intentionally does **not** document planned v0.5.0 features or the preferred future contracts tracked in the milestone. Those remain in issues until their implementations and tests land.

## What changed

- documents the current priority-queue scheduler behavior, including that `HRT_SCHED_RR` is not global priority-independent RR in v0.4.0;
- documents that `hrt_sleep(0)` currently sleeps for one tick and that `hrt_yield()` is the immediate scheduling point;
- separates the private port-owned tick path from public external `hrt_tick_from_isr()`;
- replaces obsolete port-hook documentation with the hooks used by the current reference ports;
- describes POSIX as signal-driven tick accounting with cooperative context handoff through HardRT scheduling points;
- corrects C++ wrapper names, task return values, slice-zero behavior, and queue types;
- aligns CMake prerequisites and options with the existing configuration, including CXX/ASM language enablement and UBSan-only sanitizer behavior;
- corrects semaphore and queue ISR `need_switch` semantics and removes the nonexistent yield-from-ISR example;
- removes unsupported ABI compatibility and universal latency-bound claims;
- fixes invalid unnamed C parameters across API, synchronization, and example documentation;
- qualifies STM32 timing measurements as configuration-specific observations rather than formal worst-case guarantees.

## Scope boundary

No function implementation, declaration, public type layout, constant value, CMake logic, scheduler logic, or port logic is changed. Source-file edits are limited to comments in:

- `inc/hardrt.h`
- `inc/hardrt_time.h`
- `cpp/hardrtpp.hpp`

## Related issues

Documentation portions of #1, #25, #26, #27, #29, #31, #32, #35, #36, and #37.

The behavioral changes planned for v0.5.0 remain tracked separately and are not described as current functionality.

## Validation

- reviewed documentation against the current `develop` implementation of the core scheduler, tick paths, semaphore/queue/mutex wake paths, POSIX port, Cortex-M port, C++ wrapper, examples, and CMake configuration;
- compared the branch against `develop` and confirmed that changed non-Markdown files contain documentation/comment updates only;
- Linux workflow passed on Ubuntu 22.04, Ubuntu 24.04, and ubuntu-latest;
- POSIX configure, build, and tests passed on all three runners;
- Cortex-M library configure and build passed on Ubuntu 22.04.

No runtime behavior is intentionally changed by this PR.